### PR TITLE
Added transcript filtering module based on filter_vep script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0dev - [17th March 2023]
+## v1.0dev - [31th March 2023]
 
 Initial release of cio-abcd/variantinterpretation, created with the [nf-core](https://nf-co.re/) template.
+
+- Added esnembl VEP module for VCF annnotation.
+- Added transcript filtering module based in the vep filter script.
 
 ### `Added`
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 
 1. Run Samplesheet check with modified [nf-core script](bin/check_samplesheet.py)
 2. Annotation using [Ensembl variant effect predictor (VEP)](https://www.ensembl.org/info/docs/tools/vep/index.html)
-3. Run MultiQC ([`MultiQC`](http://multiqc.info/))
+3. Filtering of transcripts using [filter_vep script](https://www.ensembl.org/info/docs/tools/vep/script/vep_filter.html).
+4. Run MultiQC ([`MultiQC`](http://multiqc.info/))
 
 ## Quick Start
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -52,4 +52,11 @@ process {
             (params.vep_out_format)         ? "--${params.vep_out_format}"  : '--vcf',
         ].join(' ').trim() }
     }
+
+    withName: ENSEMBLVEP_FILTER {
+        ext.args = { [
+            '--only_matched',
+            (params.transcriptfilter)       ? "-f \"${params.transcriptfilter} exists\"" : '',
+        ].join(' ').trim() }
+    }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -12,9 +12,10 @@ The directories listed below will be created in the results directory after the 
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
 
-- [ensemblvep](#ensemblvep) - Annotated VCF file and summary.
-- [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline
-- [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
+- [ensemblvep](#ensemblvep) - Annotates VCF file and reports summary.
+- [transcriptfilter](#transcriptfilter) - Filters for specific transcripts.
+- [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline.
+- [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution.
 
 ### Ensembl VEP
 
@@ -27,6 +28,17 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
   </details>
 
 [VEP](https://www.ensembl.org/info/docs/tools/vep/index.html) annotated variants based on provided public databases. It provides biological information as protein consequence and effect prediction as well as co-located variants from existing databases giving information, e.g., about population allele frequencies. For full overview, see the [VEP annotation sources](https://www.ensembl.org/info/docs/tools/vep/script/vep_cache.html) and [VEP command flags](https://www.ensembl.org/info/docs/tools/vep/script/vep_options.html).
+
+### Transcriptfilter
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `ensemblvep/`
+  - `*.filt.vcf`: VCF file with all variants and additional FILTER column flag.
+  </details>
+
+[VEP_filter](https://www.ensembl.org/info/docs/tools/vep/script/vep_filter.html) is a separate script in the Ensembl VEP package that separates the filter step form vep. This module has a hard-coded configuration "--soft_filter" to prevent silent dropping of variants, instead a flag "filter_vep_fail/filter_vep_pass" will be added to the FILTER column. A default external argument is also --only_matched, will results in annotation being dropped if it does not match the filtering criteria. That results in variants only having transcript annotations matching the filter criteria, variants without any matching transcript will be retained, but without any annotation.
 
 ### MultiQC
 

--- a/modules/local/ensemblvep/filter_vep/main.nf
+++ b/modules/local/ensemblvep/filter_vep/main.nf
@@ -1,0 +1,52 @@
+process ENSEMBLVEP_FILTER {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::ensembl-vep=108.2"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ensembl-vep:108.2--pl5321h4a94de4_0' :
+        'quay.io/biocontainers/ensembl-vep:108.2--pl5321h4a94de4_0' }"
+
+    input:
+    tuple val(meta), path(vcf)
+    path transcriptlist
+
+    output:
+    tuple val(meta), path("*.vcf")         , emit: vcf
+    path "versions.yml"                    , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def listfilter = transcriptlist ? "-f \"Feature in $transcriptlist\"" : ""
+
+    """
+    filter_vep \\
+        $args \\
+        -i $vcf \\
+        --format vcf \\
+        -o ${prefix}.filt.vcf \\
+        --soft_filter \\
+        $listfilter \\
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        ensemblvep: \$( echo \$(vep --help 2>&1) | sed 's/^.*Versions:.*ensembl-vep : //;s/ .*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.filt.vcf.gz
+    touch ${prefix}.summary.html
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        ensemblvep: \$( echo \$(vep --help 2>&1) | sed 's/^.*Versions:.*ensembl-vep : //;s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,6 +25,10 @@ params {
     max_multiqc_email_size     = '25.MB'
     multiqc_methods_description = null
 
+    // Transcript filtering
+    transcriptfilter            = null
+    transcriptlist              = null
+
     // VEP options
     vep                         = true
     vep_out_format              = 'vcf'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -186,6 +186,29 @@
             },
             "fa_icon": "fas fa-scroll"
         },
+        "filtering_option": {
+            "title": "Filtering option",
+            "type": "object",
+            "description": "Options for filtering VCF files",
+            "default": "",
+            "fa_icon": "fas fa-filter",
+            "properties": {
+                "transcriptfilter": {
+                    "type": "string",
+                    "default": "None",
+                    "enum": ["None", "PICK", "CANONICAL", "MANE_SELECT"],
+                    "description": "Transcript annotation column for filtering.",
+                    "help_text": "If variant does not have any match, all annotation will be removed and variant is flagged in FILTER column.\nCan work simultaneously with \"transcriptfilter\" param."
+                },
+                "transcriptlist": {
+                    "type": "string",
+                    "default": "None",
+                    "help_text": "If variant does not have any match, all annotation will be removed and variant is flagged in FILTER column.\nCan work simultaneously with \"transcriptfilter\" param.",
+                    "format": "file-path",
+                    "description": "List of transcripts for filtering."
+                }
+            }
+        },
         "institutional_config_options": {
             "title": "Institutional config options",
             "type": "object",
@@ -379,6 +402,9 @@
         },
         {
             "$ref": "#/definitions/annotation_options"
+        },
+        {
+            "$ref": "#/definitions/filtering_option"
         },
         {
             "$ref": "#/definitions/institutional_config_options"


### PR DESCRIPTION
The changes in this PR regard would close issue #10 .

It implements the filter script within the VEP package as local module.
It accepts VEP-annotated input with multiple transcripts and adds two possibilities to filter for transcripts:
1. select a column and only filter for those transcripts, for which an entry (!=".") exists. This can be the PICK, CANONICAL or MANE_SELECT columsn annotated by VEP.
2. select transcripts based on simple list of transcripts to include.

It will remove all annotations of those variants without any matching transcript, but not remove the variant.
This needs to be considered for downstream processes.
The module enables the creation of MAF file formats with only one transcript, but can be adapted to individual needs.
