### PR TITLE
TMB module based on vembrane output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 <!-- TODO nf-core: Fill in short bullet-pointed list of the default steps in the pipeline -->
 
 1. Run Samplesheet check with modified [nf-core script](bin/check_samplesheet.py)
-2. Annotation using [Ensembl variant effect predictor (VEP)](https://www.ensembl.org/info/docs/tools/vep/index.html).
-3. Filtering of transcripts using [filter_vep script](https://www.ensembl.org/info/docs/tools/vep/script/vep_filter.html).
-4. Generate a TSV file based on VCF columns including FORMAT and INFO fields and the [VEP annotation fields](https://www.ensembl.org/info/docs/tools/vep/vep_formats.html#output) encoded as CSQ strings in the INFO field using [vembrane table](https://github.com/vembrane/vembrane).
-5. Generate a HTML report using [datavzrd](https://github.com/datavzrd/datavzrd#readme).
-6. Run MultiQC ([`MultiQC`](http://multiqc.info/))
+2. Run format check on optionally provided BED file using a [python script](bin/check_bedfiles.py)
+3. Annotation using [Ensembl variant effect predictor (VEP)](https://www.ensembl.org/info/docs/tools/vep/index.html).
+4. Filtering of transcripts using [filter_vep script](https://www.ensembl.org/info/docs/tools/vep/script/vep_filter.html).
+5. Generate a TSV file based on VCF columns including FORMAT and INFO fields and the [VEP annotation fields](https://www.ensembl.org/info/docs/tools/vep/vep_formats.html#output) encoded as CSQ strings in the INFO field using [vembrane table](https://github.com/vembrane/vembrane).
+6. Calculate TMB based on provided cutoffs and thresholds for each sample using a [python script](bin/calculate_TMB.py) from the Vembrane TSV output
+7. Generate a HTML report using [datavzrd](https://github.com/datavzrd/datavzrd#readme).
+8. Run MultiQC ([`MultiQC`](http://multiqc.info/))
 
 ## Quick Start
 

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,2 +1,2 @@
 sample,vcf
-SAMPLE,/path/to/vcf/file
+SAMPLE, PATH/TO/VCF

--- a/bin/calculate_TMB.py
+++ b/bin/calculate_TMB.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+import numpy as np
+import pyranges as pr
+import matplotlib.pyplot as plt
+import seaborn as sns
+from pathlib import Path
+import argparse
+import logging
+import sys
+
+logger = logging.getLogger()
+
+
+def parse_args(argv=None):
+    """Define and immediately parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Calculate TMB and plot AF distribution",
+        epilog="Example: python3 calculate_TMB.py input.tsv",
+    )
+    parser.add_argument(
+        "--file_in",
+        metavar="file_in",
+        type=Path,
+        help="Input tsv file of the vembrane TSV converter module",
+    )
+    parser.add_argument(
+        "--bedfile",
+        metavar="bedfile",
+        type=Path,
+        help="Path to the provided BED-file with .bed suffix.",
+    )
+    parser.add_argument(
+        "--panelsize_threshold",
+        metavar="panelsize_threshold",
+        type=int,
+        help="Expected minimal size of the BED-file before giving an error.",
+    )
+    parser.add_argument(
+        "--min_AF",
+        metavar="min_AF",
+        type=float,
+        help="Minimal AF threshold for the filtering procedure of the TMB module",
+    )
+    parser.add_argument(
+        "--max_AF",
+        metavar="max_AF",
+        type=float,
+        help="Maximal AF threshold for the filtering procedure of the TMB module",
+    )
+    parser.add_argument(
+        "--min_cov",
+        metavar="min_cov",
+        type=int,
+        help="Minimal coverage threshold for the filtering procedure of the TMB module",
+    )
+    parser.add_argument(
+        "--popfreq_max",
+        metavar="popfreq_max",
+        type=float,
+        help="Maximal prevalence AF in the --population_db database",
+    )
+    parser.add_argument(
+        "--filter_muttype",
+        metavar="filter_muttype",
+        type=str,
+        choices=["snv", "snvs", "mnv", "mnvs"],
+        help="Set the conditions for filtering, either selecting only SNVs, SNVs and MNVs or the whole dataset including InDels",
+    )
+    parser.add_argument(
+        "--population_db",
+        metavar="population_db",
+        type=str,
+        help="String corresponding to the column name of the desired population database to filter on.",
+    )
+    parser.add_argument(
+        "--file_out",
+        metavar="FILE_OUT",
+        type=Path,
+        help="Per Sample TMB value",
+    )
+    parser.add_argument(
+        "--plot_out",
+        metavar="PLOT_OUT",
+        type=Path,
+        help="Stacked histogramm of the AFs in the sample",
+    )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        help="The desired log level (default WARNING).",
+        choices=("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
+        default="WARNING",
+    )
+    return parser.parse_args(argv)
+
+
+logger = logging.getLogger()
+
+
+def preprocess_vembraneout(file_in, filter_muttype, population_db):
+    TMB_inputfile = pd.read_csv(file_in, sep="\t")
+    TMB_inputfile["Mut_ID"] = TMB_inputfile[["CHROM", "POS", "REF", "ALT"]].apply(
+        lambda row: ":".join(row.values.astype(str)), axis=1
+    )
+    TMB_deduplicated = TMB_inputfile.drop_duplicates("Mut_ID", keep="first")
+    filtering_rates = []
+    filtering_rates.append(len(TMB_deduplicated["Mut_ID"]))
+    ### reduce dataset on relevant columns for TMB calculation
+    TMB_minimal = TMB_deduplicated.filter(
+        items=[
+            "Mut_ID",
+            "CHROM",
+            "POS",
+            "REF",
+            "ALT",
+            "FILTER",
+            "allele_fraction",
+            "read_depth",
+            "CSQ_VARIANT_CLASS",
+            "CSQ_Consequence",
+            population_db,
+        ],
+        axis=1,
+    )
+    if filter_muttype in ["snv", "snvs"]:
+        TMB_filtered = filter_onlySNV(TMB_minimal)
+    elif filter_muttype in ["mnv", "mnvs"]:
+        TMB_filtered = filter_retainMNV(TMB_minimal)
+    else:
+        TMB_filtered = TMB_minimal
+    filtering_rates.append(len(TMB_filtered["Mut_ID"]))
+    ### Generate position specific identifier for deduplication / counting
+    return (TMB_filtered, filtering_rates)
+
+
+def filter_onlySNV(TMB_inputfile):
+    TMB_onlySNV = TMB_inputfile[
+        (TMB_inputfile["REF"].isin(["A", "G", "T", "C"])) & (TMB_inputfile["ALT"].isin(["A", "G", "T", "C"]))
+    ].reset_index(drop=True)
+    if TMB_onlySNV["CSQ_VARIANT_CLASS"].eq("SNV").all():
+        return TMB_onlySNV
+    else:
+        TMB_onlySNV = TMB_onlySNV[(TMB_onlySNV["CSQ_VARIANT_CLASS"] == "SNV")]
+        return TMB_onlySNV
+
+
+def filter_retainMNV(TMB_inputfile):
+    TMB_SNVs = TMB_inputfile[
+        (TMB_inputfile["REF"].isin(["A", "G", "T", "C"])) & (TMB_inputfile["ALT"].isin(["A", "G", "T", "C"]))
+    ].reset_index(drop=True)
+    TMB_MNVs = TMB_inputfile[(TMB_inputfile["CSQ_VARIANT_CLASS"] == "substitution")].reset_index(
+        drop=True
+    )  ### contains DBS, SNVs close to repeats and non-normalized SNVs close to InDels
+    TMB_return = pd.concat([TMB_SNVs, TMB_MNVs])
+    return TMB_return
+
+
+def check_bed_size(bedfile, breaking_thresh):
+    panel_data = pd.read_csv(bedfile, sep="\t", header=None)
+    panel_data = panel_data.iloc[:, 0:3]
+    panel_data.columns = ["Chromosome", "Start", "End"]
+    panel_range = pr.PyRanges(panel_data)
+    panel_size = panel_range.length
+    if panel_size >= breaking_thresh:
+        if panel_size >= 1000000:
+            logger.info(
+                "The provided BED file covers "
+                + str(panel_size)
+                + " basepairs. It covers more than 1 Mbp. TMB calculation can be performed"
+            )
+            return True, panel_size
+        else:
+            logger.warning(
+                "The provided BED file covers "
+                + str(panel_size)
+                + " basepairs. It covers less than 1 Mbp, but is above the breaking threshold. TMB calculation can be performed, but could be biased."
+            )
+            return True, panel_size
+    elif panel_size < breaking_thresh:
+        logger.warning(
+            "The provided BED file covers "
+            + str(panel_size)
+            + " basepairs, but does not surpass the threshold for TMB calculation. Reconsider the threshold or provide an actualized BED-file."
+        )
+        return False, panel_size
+    else:
+        logger.warning(
+            "An unexpected error occured while parsing the BED-file size. TMB calculation will not be performed."
+        )
+        return False, False
+
+
+def coverage_filter(input, threshold):
+    TMB_covfilt = input[(input["read_depth"] >= threshold)].reset_index(drop=True)
+    filtering_rates = len(TMB_covfilt["Mut_ID"])
+    return (TMB_covfilt, filtering_rates)
+
+
+def allelefrequency_filter(input, lower_threshold, higher_threshold):
+    TMB_AFboundariesfilt = input[
+        (input["allele_fraction"] >= lower_threshold) & (input["allele_fraction"] <= higher_threshold)
+    ].reset_index(drop=True)
+    filtering_rates = len(TMB_AFboundariesfilt["Mut_ID"])
+    return (TMB_AFboundariesfilt, filtering_rates)
+
+
+def popfrequency_filter(input, database, threshold):
+    TMB_popfreqfilt = input[input[database] <= threshold].reset_index(drop=True)
+    filtering_rates = len(TMB_popfreqfilt["Mut_ID"])
+    return (TMB_popfreqfilt, filtering_rates)
+
+
+def calculate_TMB(input, panel_size):
+    TMB = round((len(input.index) / panel_size) * 1000000, 2)
+    return TMB
+
+
+def plot_TMB(input, name_convention, lower_af, higher_af):
+    ### Preprocess for plotting
+    counts_consequence = input.groupby(input.columns.tolist(), as_index=False, dropna=False).size()
+    index_filter = counts_consequence.groupby("Mut_ID")["size"].transform("max").ne(counts_consequence["size"])
+    most_prevalent_con = counts_consequence[~index_filter.values]
+    TMB_forplot = (
+        pd.DataFrame({"Mut_ID": most_prevalent_con["Mut_ID"], "CSQ_Consequence": most_prevalent_con["CSQ_Consequence"]})
+        .merge(input)
+        .drop_duplicates()
+    )
+    TMB_forplot["CSQ_Consequence"] = TMB_forplot["CSQ_Consequence"].str.split("&").str[0]  ## beautification
+    TMB_forplot = TMB_forplot.drop_duplicates("Mut_ID", keep="first")
+
+    ### Draw the plot
+    fig, ax = plt.subplots(figsize=(14, 8))
+
+    p = sns.histplot(
+        data=TMB_forplot,
+        ax=ax,
+        stat="count",
+        multiple="stack",
+        binwidth=0.01,
+        x="allele_fraction",
+        kde=False,
+        palette="colorblind",
+        hue="CSQ_Consequence",
+        element="bars",
+    )
+
+    ### Control the legend
+    sns.move_legend(p, loc="center right", bbox_to_anchor=(1.35, 0.5), ncol=1, fontsize=6)
+
+    ### Show filtering parameters
+    plt.axvline(x=lower_af, color="grey", linestyle="dotted")
+    plt.axvline(x=higher_af, color="grey", linestyle="dotted")
+
+    # Set the title and labels
+    ax.set_title("Allele frequency (AF) distribution for TMB-filtered variants")
+    ax.set_xlabel("AF in %")
+    ax.set_ylabel("# of mutations")
+    plt.xticks(np.arange(0, 1.1, 0.1))
+    ax.yaxis.get_major_locator().set_params(integer=True)  ## force integers on y-axis
+    plt.savefig(name_convention, bbox_inches="tight")
+
+
+def main(argv=None):
+    """Coordinate argument parsing and program execution."""
+    args = parse_args(argv)
+    if not args.file_in.is_file():
+        logger.error(f"The given input file {args.file_in} was not found!")
+
+    # Need to adjust parameters of zero is passed to avoid None input
+    if args.min_cov is None:
+        args.min_cov = 0.00
+    if args.min_AF is None:
+        args.min_AF = 0.00
+    if args.panelsize_threshold is None:
+        args.panelsize_threshold = 0
+
+    TMB_df, filtering_rates_total = preprocess_vembraneout(args.file_in, args.filter_muttype, args.population_db)
+    eligibility, panel_size = check_bed_size(args.bedfile, args.panelsize_threshold)
+    if eligibility == True:
+        TMB_covfilt, filtering_rates_cov = coverage_filter(TMB_df, args.min_cov)
+        TMB_affilt, filtering_rates_af = allelefrequency_filter(TMB_covfilt, args.min_AF, args.max_AF)
+        TMB_popfilt, filtering_rates_popfreq = popfrequency_filter(TMB_affilt, args.population_db, args.popfreq_max)
+        TMB_value = calculate_TMB(TMB_popfilt, panel_size)
+        filtering_rates_total = filtering_rates_total + [
+            filtering_rates_cov,
+            filtering_rates_af,
+            filtering_rates_popfreq,
+        ]
+        plot_TMB(
+            TMB_covfilt, args.plot_out, args.min_AF, args.max_AF
+        )  ### Use coverage filtered data as non-filtered data compresses plot to uselessness...
+        with open(args.file_out, "w") as file:
+            file.write(f"Inital amount of unique mutations: {filtering_rates_total[0]} mutations\n")
+            if args.filter_muttype in ["snv", "snvs", "mnv", "mnvs"]:
+                file.write(
+                    f"Retained mutations after filtering for mutation type {args.filter_muttype}: {filtering_rates_total[1]} mutations\n"
+                )
+            file.write(
+                f"Retained mutations after applying coverage filter for a threshold below {args.min_cov}: {filtering_rates_total[2]} mutations\n"
+            )
+            file.write(
+                f"Retained mutations after filtering for AF between {args.min_AF} and {args.max_AF}: {filtering_rates_total[3]} mutations\n"
+            )
+            file.write(
+                f"Retained mutations after filtering for the population AF from {args.population_db} below {args.popfreq_max}: {filtering_rates_total[4]} mutations\n"
+            )
+            file.write(
+                f"The final TMB based on these filtering conditions and a panel size of {panel_size}: {TMB_value} mutations/Mbp"
+            )
+    else:
+        logger.info("The calculation was not performed as the panel_size is below the allowed threshold.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/check_bedfiles.py
+++ b/bin/check_bedfiles.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+from pathlib import Path
+import sys
+import argparse
+import logging
+
+logger = logging.getLogger()
+
+### Set the values which could occur in a well structured bed file
+
+chroms = {
+    "chr1",
+    "chr2",
+    "chr3",
+    "chr4",
+    "chr5",
+    "chr6",
+    "chr7",
+    "chr8",
+    "chr9",
+    "chr10",
+    "chr11",
+    "chr12",
+    "chr13",
+    "chr14",
+    "chr15",
+    "chr16",
+    "chr17",
+    "chr18",
+    "chr19",
+    "chr20",
+    "chr21",
+    "chr22",
+    "chrX",
+    "chrY",
+    "chrM",
+}
+
+### Function to read in the input bed file
+
+
+def parse_args(argv=None):
+    """Define and immediately parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Validate the structure of the provided BED-sheet.",
+        epilog="Example: python3 check_bedfiles.py file.bed",
+    )
+    parser.add_argument(
+        "file_in",
+        metavar="FILE_IN",
+        type=Path,
+        help="File with .bed suffix.",
+    )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        help="The desired log level (default WARNING).",
+        choices=("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
+        default="WARNING",
+    )
+    return parser.parse_args(argv)
+
+
+### Function to check if the BED file provided can be used for bcftools and PyRanges
+
+
+def check_bed_structure(bed_input):
+    colcheck = pd.read_csv(bed_input, sep="\t", header=None)
+    header_test = any(
+        isinstance(value, str) for value in colcheck.iloc[0, 1:2]
+    )  ## checks for no full strings in positional argument columns, as chr is interpreted as str
+    if (
+        len(colcheck.columns) >= 3 and header_test == False
+    ):  ### Should contain at least three columns CHROM, POS, END without header
+        chrom_valid = check_chromosome_col(colcheck.iloc[:, 0])
+        start_valid = check_integer_col(colcheck.iloc[:, 1])
+        end_valid = check_integer_col(colcheck.iloc[:, 2])
+        order_check = check_startend_col(colcheck)
+        if chrom_valid == True:
+            if start_valid == True and end_valid == True and order_check == True:
+                return True
+            else:
+                return False
+        else:
+            return False
+    else:
+        logger.error(
+            "The provided BED file doesn't follow the required format. Please provide a BED file containing the minimal information (Chromosome, Start, End) without an header. TMB will not be calculated."
+        )
+        raise ValueError(
+            f"The provided BED file doesn't follow the required format. Please provide a BED file containing the minimal information (Chromosome, Start, End) without an header. TMB will not be calculated."
+        )
+
+
+def check_chromosome_col(input):
+    column = input.isin(chroms)
+    column_nonvalid_rows = column.index[column == False].tolist()
+    validity = column.all()
+    if validity == True:
+        logger.info("The Chromosome column is valid.")
+        return True
+    else:
+        logger.error(
+            'The Chromosome column contains values not following the "chr1-chr22/X/Y" convention. Please check the rows ',
+            column_nonvalid_rows,
+            " for problems.",
+        )
+        return False
+
+
+def check_integer_col(input):
+    column = input.map(type).eq(int)
+    validity = column.all()
+    if validity == True:
+        logger.info("The positional argument column only contains integers.")
+        return True
+    else:
+        logger.error(
+            "The positional argument column contains non-integer values. Please check your start/end column for problems."
+        )
+        return False
+
+
+def check_startend_col(input):
+    all_rows_valid = all(input.iloc[:, 1] < input.iloc[:, 2])
+    if all_rows_valid == False:
+        nonvalid_rows = input[input.iloc[:, 1] >= input.iloc[:, 2]].index.tolist()
+        logger.error(
+            "Not all start positions are smaller than their respective end positions. Please check the rows ",
+            nonvalid_rows,
+            " for problems.",
+        )
+        return False
+    else:
+        return True
+
+
+def main(argv=None):
+    """Coordinate argument parsing and program execution."""
+    args = parse_args(argv)
+    logging.basicConfig(level=args.log_level, format="[%(levelname)s] %(message)s")
+    if not args.file_in.is_file():
+        logger.error(f"The given input file {args.file_in} was not found!")
+        raise ValueError(f"The given input file {args.file_in} was not found!")
+    else:
+        bed_well_structured = check_bed_structure(args.file_in)
+        if bed_well_structured == True:
+            structured_out = pd.DataFrame({"bed_well_structured": [bed_well_structured]})
+            structured_out.to_csv("bed_stats_structure.txt", header=False, index=False)
+        else:
+            raise ValueError(
+                f"The given BED file is not well structured! Please check for floats, strings or thereof in your file!"
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -65,6 +65,18 @@ process {
         ].join(' ').trim() }
     }
 
+    withName: TMB_CALCULATE  {
+        ext.args = { [
+        (params.min_af)                     ? "--min_AF ${params.min_af}"                           :   "",
+        (params.max_af)                     ? "--max_AF ${params.max_af}"                           :   "",
+        (params.min_cov)                    ? "--min_cov ${params.min_cov}"                         :   "",
+        (params.max_popfreq)                ? "--popfreq_max ${params.max_popfreq}"                 :   "",
+        (params.filter_muttype)             ? "--filter_muttype ${params.filter_muttype}"           :   "",
+        (params.population_db)              ? "--population_db ${params.population_db}"             :   "--population_db 'CSQ_gnomADe_AF'",
+        (params.panelsize_threshold)        ? "--panelsize_threshold ${params.panelsize_threshold}" :   "",
+        ].join(' ').trim()  }
+    }
+
     withName: ENSEMBLVEP_FILTER {
         ext.args = { [
             '--only_matched',

--- a/docs/output.md
+++ b/docs/output.md
@@ -16,6 +16,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 - [transcriptfilter](#transcriptfilter) - Filters for specific transcripts.
 - [vembrane table](#vembranetable) - Generates TSV output based on provided VEP annotation fields
 - [datavzrd](#datavzrd) - Generates HTML report based on TSV file.
+- [TMB calculate](#tmbcalculate) - Calculates the TMB per sample based on provided cutoffs from vembrane TSV output
 - [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline.
 - [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution.
 
@@ -65,6 +66,18 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 [Datavzrd](https://github.com/datavzrd/datavzrd#readme) generates a HTML report from TSV files based on a YAML configuration file. The HTML report enables several features including interactive filtering, links within the data or to the internet, plotting, etc.
 The configuration file is rendered using the [YTE template engine](https://github.com/yte-template-engine/yte#readme) that enables usage of python code in YAML files for dynamic rendering.
 This module comes with two assets: The [datavzrd_config_template.yaml](../assets/datavzrd_config_template.yaml) which uses information about the annotation columns specified in [annotation_colinfo.tsv](../assets/annotation_colinfo.tsv) for rendering the datavzrd config. Find more information in the parameters help text.
+
+### TMB calculation
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `tmb/`
+  - `*.txt`: Single value TXT file containing the TMB value calculated from the vembrane TSV output after applying allele frequency, coverage and population frequency thresholds.
+  - `*.png`: Non-interactive Barplot visualizing the count of mutations against their respective allele frequency
+  </details>
+
+[TMB calculation](bin/calculate_TMB.py) generates a single value TXT file containing the Tumor Mutational Burden (TMB) as single value. The calculation will be performed on the vembrane TSV output file, allowing for prefiltering of unwanted mutations using the vep-filter step prior to TMB calculation. TMB calculation will only be performed if a [well-formatted BED file](https://genome.ucsc.edu/FAQ/FAQformat.html#format1) covering at least 1 MBp in its target regions was provided to the workflow. TMB calculation is not a unified and standarized process, thus different thresholds can be provided including a lower and upper allele frequency boundary, a minimal threshold for coverage, a maximal threshold for presence in the [gnomAD global population frequency](https://gnomad.broadinstitute.org/) and a flag to filter InDels from the calculation procedure.
 
 ### MultiQC
 

--- a/modules/local/checkbedfile.nf
+++ b/modules/local/checkbedfile.nf
@@ -1,0 +1,37 @@
+
+process CHECKBEDFILE {
+    tag '$bed_file'
+    label 'process_single'
+
+    conda "conda-forge::python=3.8.3 conda-forge::pandas=2.0.3"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-371b28410c3e53c7f9010677515b1b0eb3764999:0267f53936b6c04b051e07833c218f1fdd2a7cac-0' :
+        'biocontainers/mulled-v2-371b28410c3e53c7f9010677515b1b0eb3764999:0267f53936b6c04b051e07833c218f1fdd2a7cac-0' }"
+
+    input:
+    path bedfile
+
+    output:
+    env  valid_structure						, emit: bed_valid
+    path "versions.yml"							, emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script: // This script is bundled with the pipeline, in cio-abcd/variantinterpretation/bin/
+    """
+    check_bedfiles.py \\
+        $bedfile
+
+    if [ -f "bed_stats_structure.txt" ]; then
+        valid_structure=true
+    else
+        valid_structure=false
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+}

--- a/modules/local/samplesheet_check.nf
+++ b/modules/local/samplesheet_check.nf
@@ -5,7 +5,7 @@ process SAMPLESHEET_CHECK {
     conda "conda-forge::python=3.8.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/python:3.8.3' :
-        'quay.io/biocontainers/python:3.8.3' }"
+        'biocontainers/python:3.8.3' }"
 
     input:
     path samplesheet

--- a/modules/local/tmbcalculation/main.nf
+++ b/modules/local/tmbcalculation/main.nf
@@ -1,0 +1,40 @@
+process TMB_CALCULATE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "conda-forge::python=3.8.3 conda-forge::pandas=2.0.3 conda-forge::numpy=1.25.1 conda-forge::matplotlib=3.6.3 conda-forge::seaborn=0.12.2 conda-forge::pyranges=0.0.117"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-371b28410c3e53c7f9010677515b1b0eb3764999:0267f53936b6c04b051e07833c218f1fdd2a7cac-0' :
+        'quay.io/biocontainers/mulled-v2-371b28410c3e53c7f9010677515b1b0eb3764999:0267f53936b6c04b051e07833c218f1fdd2a7cac-0' }"
+
+    input:
+    tuple val(meta), path(tsv)
+    path bedfile
+
+    output:
+    tuple val(meta), path("*.txt"), emit: TMB_txt
+    tuple val(meta), path("*.png"), emit: TMB_png
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    # Calculate TMB
+    calculate_TMB.py \\
+        --file_in $tsv \\
+        --bedfile $bedfile\\
+        $args \\
+        --file_out ${prefix}.txt \\
+        --plot_out ${prefix}.png
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,6 +25,9 @@ params {
     max_multiqc_email_size     = '25.MB'
     multiqc_methods_description = null
 
+    // Bedfile options
+    bedfile			= null
+
     // Transcript filtering
     transcriptfilter            = null
     transcriptlist              = []
@@ -61,6 +64,16 @@ params {
     report                      = true
     datavzrd_config             = null
     annotation_colinfo          = null
+
+    // TMB calculation options
+    calculate_tmb		        = false
+    min_af			            = 0.00
+    max_af			            = 1.00
+    min_cov			            = 10
+    max_popfreq			        = 0.02
+    filter_muttype		        = 'snv'
+    population_db               = null
+    panelsize_threshold		    = 1000000
 
     // Boilerplate options
     outdir                     = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -79,6 +79,18 @@
                 }
             }
         },
+        "preprocessing_options": {
+            "title": "Preprocessing options",
+            "type": "object",
+            "description": "Options related to prefiltering routines (e.g. BED file)",
+            "default": "",
+            "properties": {
+                "bedfile": {
+                    "type": "string",
+                    "description": "BED file of the sequencing panel used for VCF generation"
+                }
+            }
+        },
         "annotation_options": {
             "title": "Annotation options",
             "type": "object",
@@ -264,6 +276,52 @@
                     "type": "string",
                     "description": "TSV file giving information about annotations and how to render them for HTML report.",
                     "help_text": "This TSV file contains six unique columns:  \n- identifier: Name of the corresponding annotation column in the variant TSV file. This column is used to match the variant TSV columns. The variant TSV column names will be adapted for better matching that needs to be considered when defining those identifiers: The matching is case-insensitive, disregards \"CSQ_\" prefixes and only allows letters, numbers and underscores. Square brackets will be replaced with a \"-\", Mathematical operands in variant TSV column names will be replaced with literal strings: \"+\" is replaced with \"-plus-\", \"-\" with \"-minus-\", \"*\" with \"-times-\", \"/\" with \"-divided-by-\", \"%\" with \"-modulus-\". For example: If the variant TSV column name is FORMAT_AD[1]/FORMAT_DP, the identifier has to have the name FORMAT_AD-1--divided-by-FORMAT_DP and can have lower or upper cases.\n\n- label: new label that will be shown in HTML report if display = normal.  \n\n- group: The columns of the variant TSV file will be splitted into group-specific TSV files to make the report better accessible. This column defines the specific group names. Each group will be linked to each other. However, accessing columns between groups in the datavzrd_config file is not possible.  \n\n- display: Allows 'normal', 'detail' and 'hidden'  according to the display-mode parameter in datavzrd. \"normal\" shows the column, \"detail\" puts it in detail view accessible with \"+\", \"hidden\" does not show it in the HTML report, but in the exported excel table.  \n\n- data_type and data_type_value: Both columns determines implemented automatic rendering in this workflow:\n  - data_type=__integer or float__: Will create a [ticks plot](https://vega.github.io/vega-lite/docs/tick.html)\n    - if data_type_value=min=NUM1,max=NUM2 key-value pairs are specified, will set the range of tick plot.\n  - data_type=__string__: Creates heatmap plot if `data_type_value` has fieldname=color key=value pairs specifying the color literally or in hexcode.\n  - data_type=___link__: Creates a hyperlink if `data_type_value` provides name=url key=value pairs. Can refer to entries of the same row and group with the respective column name in curly brackets in lower cases.\n\nThe order of the rows in this file determines the order of columns shown in the HTML report.\nEach group report will always show the identifier columns \"chrom\", \"pos\", \"ref\", \"alt\", \"id\", and \"Feature\" that are needed to reference between group tables."
+                }
+            }
+        },
+        "tmb_calculation_options": {
+            "title": "TMB Calculation options",
+            "type": "object",
+            "description": "Options related to cutoffs in TMB calculation",
+            "default": "",
+            "properties": {
+                "calculate_tmb": {
+                    "type": "boolean",
+                    "description": "Enable TMB calculation"
+                },
+                "min_af": {
+                    "type": "number",
+                    "default": 0.0,
+                    "description": "Minimal allele frequency cutoff for TMB calculation"
+                },
+                "max_af": {
+                    "type": "number",
+                    "default": 1.0,
+                    "description": "Maximal allele frequency cutoff for TMB calculation"
+                },
+                "min_cov": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Minimal coverage cutoff for TMB calculation"
+                },
+                "max_popfreq": {
+                    "type": "number",
+                    "default": 0.02,
+                    "description": "Maximal population allele frequency in the gnomAD global population for TMB calculation"
+                },
+                "filter_muttype": {
+                    "type": "string",
+                    "description": "Define if only SNVs, SNVs and MNVs or all mutation types should be selected for TMB calculation",
+                    "default": "snv"
+                },
+                "population_db": {
+                    "type": "string",
+                    "description": "Define an alternative population database to filter annotated mutations based on population frequency"
+                },
+                "panelsize_threshold": {
+                    "type": "integer",
+                    "default": 1000000,
+                    "description": "Expected panelsize threshold which should be surpassed to calculate TMB"
                 }
             }
         },
@@ -464,6 +522,9 @@
             "$ref": "#/definitions/reference_genome_options"
         },
         {
+            "$ref": "#/definitions/preprocessing_options"
+        },
+        {
             "$ref": "#/definitions/annotation_options"
         },
         {
@@ -474,6 +535,9 @@
         },
         {
             "$ref": "#/definitions/html_report"
+        },
+        {
+            "$ref": "#/definitions/tmb_calculation_options"
         },
         {
             "$ref": "#/definitions/institutional_config_options"


### PR DESCRIPTION
This PR adds a TMB calculation module based on the TSV output from vembrane.

## Features

- New local modules: Check_bedfiles and TMB-calculation

### Check_bedfiles

- Using the parameter **bedfile**, a path to a BED file can be provided. The BED file should contain three columns without a header covering the chromosome, the start and the end position (as genomic position) to ensure compability with bcftools and PyRanges.
- The check_bedfiles controls the structure of the BED file for compability and generates three output files (bed_stats_structure.txt, bed_stats_eligibility.txt and bed_stats_size.txt). The two latter ones are only created, if the BED file covers more than 1 MBp of genetic regions. The generation of these files as optional outputs sets the conditional logic for other modules (e.g. prefiltering of regions using bcftools and TMB calculation) in Nextflow.
- If a BED file was provided and the bed_stats_eligibility.txt file exists, TMB calculation will be performed after vembrane TSV output was generated if so desired.

### TMB calculation

- TMB calculation will be performed if the option **--calculate_tmb true** is provided and the bed_stats_eligibility.txt file exists.
- TMB calculation will be performed based on provided thresholds **min_af, max_af, min_cov and max_popfreq**. Furthermore, a filtering for InDels can be performed by setting the parameter **filter_indels** to "true".
- TMB values will be generated as a .txt file per VCF based on the provided filtering thresholds.
- A .png per input file will be created which plots the distribution of variants based on consequence and allele frequency. The .png is not interactive.

## To-Do's and further enhancements

- Improve the calculcation based on input BAM files, accounting for variants on locally amplified or lost copy-number segments as further QC for allele frequencies of variants, influencing the filtering thresholds.
- Generate an alternative VCF-based calculcation module to circumvent TMB underestimation due to filtered variants in the TSV output (e.g. filter_vep), which would be otherwise eligible.
- Improve visualization of variant distribution by making the plot interactive.
- Collect TMB values per input VCF in a single output file.
- Implement results from TMB calculation into the HTML report.
- Run prettier...