### PR TITLE
change create-vembrane-fields module to have the same header name for allele_fraction

### DIFF
--- a/assets/annotation_colinfo.tsv
+++ b/assets/annotation_colinfo.tsv
@@ -5,7 +5,7 @@ VARIANT_CLASS	variant class	overview	normal	string	{SNV=darkgreen,substitution=b
 Existing_variation	variant ID	overview	normal	string
 SYMBOL	gene symbol	overview	normal	link	NCBI=https://www.ncbi.nlm.nih.gov/gene/{gene}
 EXON	exon	overview	normal	string
-format_ad-1--divided-by-format_dp	allele fraction	overview	normal	float	min=0,max=1
+allele_fraction	allele fraction	overview	normal	float	min=0,max=1
 format_dp	coverage	overview	normal	integer
 MAX_AF	population allele frequency	overview	normal	float	min=0,max=1
 MAX_AF_POPS	population allele frequency database	overview	normal	string

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -74,7 +74,11 @@ process {
 
     withName: VEMBRANE_CREATE_FIELDS {
         ext.args = { [
-            'CHROM, POS, ID, REF, ALT, QUAL, FILTER'
+            '--other_fields CHROM,POS,ID,REF,ALT,QUAL,FILTER',
+            (params.allele_fraction)        ? "--allele_fraction ${params.allele_fraction}" : '',
+            (params.format_fields)          ? "--format_fields ${params.format_fields}"     : '',
+            (params.info_fields)            ? "--info_fields ${params.info_fields}"         : '',
+            '--sampleindex 0',
         ].join(' ').trim() }
     }
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -51,7 +51,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
   - `*.tsv`: TSV file containing all fields provided by --extraction_fields, default: CHROM, POS, REF, ALT
   </details>
 
-[Vembrane table](https://github.com/vembrane/vembrane#readme) generates TSV files based on information found in the VCF header structure and can parse annotation information from CSQ strings in the INFO field. This module can extract all annotation fields found in the [VEP output documentation](https://www.ensembl.org/info/docs/tools/vep/vep_formats.html#output), which need to be provided by --annotation_fields as comma-separated values. Further, fields from the FORMAT and INFO columns of the VCF file can be extracted with the --format_fields and --info_fields parameter. In all these parameters, you can also specify mathematical operations between fields as shown for `vembrane table` examples. Those are used in the allele fraction calculation, for which some default fields are extracted when using the --allele_fraction parameter.
+[Vembrane table](https://github.com/vembrane/vembrane#readme) generates TSV files based on information found in the VCF header structure. It can parse Information from the FORMAT, INFO and other vcf columns and specifically parses annotation information from CSQ strings in the INFO field, see also the [VEP output documentation](https://www.ensembl.org/info/docs/tools/vep/vep_formats.html#output). It can also handle calculations between parameters and calculates the allele fraction.
 
 ### Datavzrd
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -108,7 +108,6 @@
                 },
                 "vep_cache": {
                     "type": "string",
-                    "default": "None",
                     "description": "Define offline cache used for VEP.",
                     "help_text": "Define offline cache used for VEP. Mandatory for running VEP. Has to be a file path."
                 },
@@ -120,7 +119,6 @@
                 },
                 "vep_cache_source": {
                     "type": "string",
-                    "default": "None",
                     "help_text": "Leave empty (null) if ensembl (standard) cache is used.",
                     "enum": ["None", "refseq", "merged"],
                     "description": "Specified VEP cache. Either Ensembl (default, null), Refseq or merged."
@@ -195,22 +193,20 @@
             "properties": {
                 "transcriptfilter": {
                     "type": "string",
-                    "default": "None",
                     "enum": ["None", "PICK", "CANONICAL", "MANE_SELECT"],
                     "description": "Transcript annotation column for filtering.",
                     "help_text": "If variant does not have any match, all annotation will be removed and variant is flagged in FILTER column.\nCan work simultaneously with \"transcriptfilter\" param."
                 },
                 "transcriptlist": {
                     "type": "string",
-                    "default": "None",
                     "help_text": "If variant does not have any match, all annotation will be removed and variant is flagged in FILTER column.\nCan work simultaneously with \"transcriptfilter\" param.",
                     "format": "file-path",
                     "description": "List of transcripts for filtering."
                 }
             }
         },
-        "vembrane_table_options": {
-            "title": "Vembrane table options",
+        "tsv_conversion_options": {
+            "title": "TSV conversion options",
             "type": "object",
             "description": "",
             "default": "",
@@ -224,8 +220,8 @@
                     "type": "string",
                     "default": "FORMAT_AD",
                     "description": "Specify how to extract and calculate the allele fraction from the VCF file.",
-                    "help_text": "The allele fraction (AF) of a variant is not always reported directly in the VCF file, but encoded indirectly in the FORMAT column. The AF is extracted or calculated  in the `vembrane table` module.   \nWithin the FORMAT column are some standard fields from which the AF can be calculated:   \n\n- **DP:** Depth or coverage, number of reads at this position.  \n- **AD:** Allelic depth, Number of reads supporting REF and ALT alleles (comma-separated, can be addressed with [0] or [1] as index)  \n\nDividing the allelic depth by the coverage gives the AF, which can be invoked with `FORMAT_AD`. Some VCF files also directly encode the AF in the FORMAT column as `AF` field, which can be invoked with `FORMAT_AF`.  \nFor the following variant callers, some defaults were specified that can be invoked by the name of the caller:  \n\n- **Freebayes** uses the `FORMAT_AD` method dividing ALT allele readnumbers (AD[1]) by depth (DP)   \n- **Mutect2** uses the AF field in the FORMAT column as defined in `FORMAT_AF` method. It is a probabilistic AF estimate, hence it is different compared to AF calculated with DP and AD column. Additionally, the DP field is also in the INFO column and will be extracted, which can be greater as the DP field in the FORMAT column as it also contains uninformative reads. So there can be three different ways of calculating the AF. Sources: [[1]](https://gatk.broadinstitute.org/hc/en-us/community/posts/4566282375835-Mutect2-AF-does-not-match-AD-and-DP),[[2]](https://github.com/broadinstitute/gatk/issues/6067),[[3]](https://gatk.broadinstitute.org/hc/en-us/articles/360035532252-Allele-Depth-AD-is-lower-than-expected).   \n- **Strelka:** Has DP values for SNVs and other coverage values for InDels in the DPI field, hence both are calculated.",
-                    "enum": ["FORMAT_AF", "mutect2", "FORMAT_AD", "strelka"]
+                    "help_text": "The allele fraction (AF) of a variant is not always reported directly in the VCF file, but encoded indirectly in the FORMAT column. The AF is extracted or calculated  in the `vembrane table` module.   \nWithin the FORMAT column are some standard fields from which the AF can be calculated:   \n\n- **DP:** Depth or coverage, number of reads at this position.  \n- **AD:** Allelic depth, Number of reads supporting REF and ALT alleles (comma-separated, can be addressed with [0] or [1] as index)  \n\nDividing the allelic depth by the coverage gives the AF, which can be invoked with `FORMAT_AD`. Some VCF files also directly encode the AF in the FORMAT column as `AF` field, which can be invoked with `FORMAT_AF`.  \nFor the following variant callers, some defaults were specified that can be invoked by the name of the caller:  \n\n- **Freebayes** uses the `FORMAT_AD` method dividing ALT allele readnumbers (AD[1]) by depth (DP)   \n- **Mutect2** uses the AF field in the FORMAT column as defined in `FORMAT_AF` method. It is a probabilistic AF estimate, hence it is different compared to AF calculated with DP and AD column. Additionally, the DP field is also in the INFO column and will be extracted, which can be greater as the DP field in the FORMAT column as it also contains uninformative reads. So there can be three different ways of calculating the AF. Sources: [[1]](https://gatk.broadinstitute.org/hc/en-us/community/posts/4566282375835-Mutect2-AF-does-not-match-AD-and-DP),[[2]](https://github.com/broadinstitute/gatk/issues/6067),[[3]](https://gatk.broadinstitute.org/hc/en-us/articles/360035532252-Allele-Depth-AD-is-lower-than-expected). ",
+                    "enum": ["FORMAT_AF", "mutect2", "FORMAT_AD", "freebayes"]
                 },
                 "annotation_fields": {
                     "type": "string",
@@ -239,7 +235,6 @@
                 },
                 "info_fields": {
                     "type": "string",
-                    "default": "None",
                     "description": "Comma-separated fields with INFO fields from VCF INFO column to include in TSV output."
                 }
             }
@@ -257,7 +252,6 @@
                 },
                 "datavzrd_config": {
                     "type": "string",
-                    "default": "null",
                     "description": "YAML file storing the configurations for datavzrd. Will be rendered using YTE template engine interpreting python code. By default uses datavzrd_config_template.yaml in the workflow `assets/`.",
                     "help_text": "YTE rendering adds group- and column-specific datavzrd configurations that are specified in annotation_colinfo (see help text of annotation_colinfo).\nDuring YAML rendering, the information from the annotation_colinfo file is accessible in the template config file.\nThese can be accessed through the respective column name. The column \"data_type_value\" will be converted to a dictionary."
                 },
@@ -471,7 +465,7 @@
             "$ref": "#/definitions/filtering_option"
         },
         {
-            "$ref": "#/definitions/vembrane_table_options"
+            "$ref": "#/definitions/tsv_conversion_options"
         },
         {
             "$ref": "#/definitions/html_report"

--- a/subworkflows/local/vembrane_table/main.nf
+++ b/subworkflows/local/vembrane_table/main.nf
@@ -10,16 +10,12 @@ workflow VEMBRANE_TABLE {
     take:
     vcf                 // channel: [ val(meta), vcf ]
     annotation_fields   // value: Annotation fields in INFO column
-    format_fields       // value: FORMAT fields
-    info_fields         // value: INFO fields
 
     main:
     ch_versions = Channel.empty()
 
     VEMBRANE_CREATE_FIELDS (vcf,
-                            annotation_fields,
-                            format_fields,
-                            info_fields
+                            annotation_fields
     )
     ch_versions = ch_versions.mix(VEMBRANE_CREATE_FIELDS.out.versions)
 

--- a/workflows/variantinterpretation.nf
+++ b/workflows/variantinterpretation.nf
@@ -50,24 +50,6 @@ vep_cache_version          = params.vep_cache_version       ?: Channel.empty()
 vep_genome                 = params.vep_genome              ?: Channel.empty()
 vep_species                = params.vep_species             ?: Channel.empty()
 annotation_fields          = params.annotation_fields       ?: ''
-format_fields              = params.format_fields           ?: ''
-info_fields                = params.info_fields             ?: ''
-
-// Convert specific format field parameters of variant callers
-if ( params.allele_fraction ) {
-    if (params.allele_fraction.contains('FORMAT_AF') || params.allele_fraction.contains('mutect2')) {
-        format_fields = format_fields ? format_fields + (' AF') : 'AF'
-        if (params.allele_fraction.contains('mutect2')) {
-            info_fields = info_fields ? info_fields + (' DP') : 'DP'
-        }
-    }
-    if (params.allele_fraction.contains('FORMAT_AD') || params.allele_fraction.contains('freebayes')) {
-        format_fields = format_fields ? format_fields + (' AD[1]/DP') : 'AD[1]/DP'
-    }
-    if (params.allele_fraction.contains('strelka')) {
-        format_fields = format_fields ? format_fields + (' DPI AD[1]/DP AD[1]/DPI') : 'DPI AD[1]/DP AD[1]/DPI'
-    }
-}
 
 // VEP extra files
 vep_extra_files            = []
@@ -170,15 +152,11 @@ workflow VARIANTINTERPRETATION {
     if ( params.tsv ) {
         if ( params.transcriptfilter || (params.transcriptlist!=[]) ) {
             VEMBRANE_TABLE (ENSEMBLVEP_FILTER.out.vcf,
-                            annotation_fields,
-                            format_fields,
-                            info_fields
+                            annotation_fields
             )
         } else {
             VEMBRANE_TABLE (ENSEMBLVEP_VEP.out.vcf,
-                            annotation_fields,
-                            format_fields,
-                            info_fields
+                            annotation_fields
             )
         }
         ch_versions = ch_versions.mix(VEMBRANE_TABLE.out.versions)


### PR DESCRIPTION
This small PR changes the implementation of the vembrane create_fields module.
It does not add features, but makes the code more readableand flexible.
It also fixes an issue with the header name of the allele fraction, which is now consistently named "allele_fraction" independent of calculation/extraction method.
The following changes were done:

- bash code from `create-vembrane-fields` module was implemented in python
- value channels for info and format fields were removed for parameter insertion in `conf/modules.config`
- allele_fraction formatting of vembrane string was implemented in python. The "strelka" option was removed as this was not working.