### PR TITLE
Add predefined filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Initial release of cio-abcd/variantinterpretation, created with the [nf-core](ht
 
 - Added ensembl VEP module for VCF annnotation.
 - Added transcript filtering module based in the vep filter script.
+- Added custom filter options with vembrane
 - Added TSV conversion module with vembrane
 - Added allele fraction calculation
 - Added HTML report generation with datavzrd

--- a/assets/custom_filters.tsv
+++ b/assets/custom_filters.tsv
@@ -1,0 +1,4 @@
+name	filter
+high_qual	FORMAT["DP"][0] > 100 and (FORMAT["AD"][0][1] / FORMAT["DP"][0]) > 0.02
+pathogenic	not {"pathogenic","likely_pathogenic","drug_response"}.isdisjoint(CSQ["CLIN_SIG"])
+BRCAgenes	CSQ["SYMBOL"] in {"BRCA2","BRCA1"}

--- a/bin/create_vembrane_tags.py
+++ b/bin/create_vembrane_tags.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+import pandas as pd
+import argparse
+import re
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Reads in TSV file with filter definitions and formats into vembrane tag input. \
+        The general filter expression follow a python syntax with the guidelines at https://github.com/vembrane/vembrane#vembrane-filter"
+    )
+    parser.add_argument(
+        "--filterdefinitions",
+        help="tab-separated file with filter name in first column and filter expression in second column.",
+        type=str,
+    )
+
+    return parser.parse_args()
+
+
+def input_check(input_strings):
+    for input_string in input_strings:
+        if re.fullmatch(r"^[A-Za-z0-9_]+$", input_string) is None:
+            raise ValueError(
+                f'Error: The input_field "{input_string}" should only contain letters, numbers and underscores.'
+            )
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+
+    # import predefined filters from TSV
+    filterdef_df = pd.read_csv(
+        args.filterdefinitions,
+        sep="\t",
+    )
+
+    # check TSV file structure
+    if not ["name", "filter"] == list(filterdef_df.columns):
+        raise ValueError(
+            f'Error: The specified filter TSV file does not have two columns named "name" and "filter": "{args.filterdefinitions}".'
+        )
+    # only allow numbers, letters and underscore for filter names
+    input_check(filterdef_df["name"])
+
+    # format for tagging
+    filter_argument = "--tag=" + filterdef_df["name"] + "='" + filterdef_df["filter"] + "'"
+
+    # concatenate
+    filters = " ".join(filter_argument)
+
+    print(filters)

--- a/conf/modules/modules.config
+++ b/conf/modules/modules.config
@@ -115,6 +115,28 @@ process {
         ].join(' ').trim() }
     }
 
+    withName: VEMBRANE_TAG {
+        publishDir = [
+            path: { "${params.outdir}/variantfilter" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.args = { [
+            '--annotation-key CSQ',
+        ].join(' ').trim() }
+    }
+
+    withName: VEMBRANE_FILTER {
+        publishDir = [
+            path: { "${params.outdir}/variantfilter" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.args = { [
+            '--annotation-key CSQ',
+        ].join(' ').trim() }
+    }
+
     withName: PREPROCESS_DATAVZRD {
         ext.args = { [
             '--ann_name_column identifier',

--- a/docs/output.md
+++ b/docs/output.md
@@ -16,6 +16,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 - [vcf proc](#vcfproc) - Filters and normalizes variant sin vcf file.
 - [ensemblvep](#ensemblvep) - Annotates VCF file and reports summary.
 - [transcriptfilter](#transcriptfilter) - Filters for specific transcripts.
+- [variantfilter](#variantfilter) - Tags VCF file with custom filters and creates separate TSV and HTML files for defined VCF subsets.
 - [vembrane table](#vembranetable) - Generates TSV output based on provided VEP annotation fields
 - [datavzrd](#datavzrd) - Generates HTML report based on TSV file.
 - [TMB calculate](#tmbcalculate) - Calculates the TMB per sample based on provided cutoffs from vembrane TSV output
@@ -91,6 +92,19 @@ Also runs variant normalization using `bcftools norm` with optional InDel left-a
   </details>
 
 [VEP_filter](https://www.ensembl.org/info/docs/tools/vep/script/vep_filter.html) is a separate script in the Ensembl VEP package that separates the filter step form vep. This module has a hard-coded configuration "--soft_filter" to prevent silent dropping of variants, instead a flag "filter_vep_fail/filter_vep_pass" will be added to the FILTER column. A default external argument is also --only_matched, will results in annotation being dropped if it does not match the filtering criteria. That results in variants only having transcript annotations matching the filter criteria, variants without any matching transcript will be retained, but without any annotation.
+
+### Variantfilter
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `variantfilter/`
+  - `*_tag.vcf`: VCF file with all custom filters tagged in the FILTER column.
+  - `*_{filtername}.vcf`: VCF file subset only containing variants from specific filter subset.
+  </details>
+
+The variantfilter can tag specific filter based on custom criteria using [vembrane tag](https://github.com/vembrane/vembrane#vembrane-tag). Filters are defined in python format readable for vembrane within a separate TSV file provided with `--custom_filters` parameter an example is provided in `assets/custom_filters.tsv` and loaded per default.
+The custom_filters can also be used to create separate TSV files and HTML reports for a filter subset. If specified with the parameter `--used_filters` the filter tag is selected using [vembrane filter](https://github.com/vembrane/vembrane#vembrane-filter). This creates additional reports, while the full VCf file is always preserved.
 
 ### Vembrane table
 

--- a/modules/local/vembrane/create-vembrane-tags/main.nf
+++ b/modules/local/vembrane/create-vembrane-tags/main.nf
@@ -1,0 +1,31 @@
+process VEMBRANE_CREATE_TAGS {
+    label 'process_single'
+    conda "conda-forge::python=3.9.15 conda-forge::pandas=2.0.3 conda-forge::numpy=1.25.2"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-0594c09780adaaa41fe60b1869ba41c8905a0c98:24a8102d6795963b77f04bb83cc82c081e4a2adc-0' :
+        'quay.io/biocontainers/mulled-v2-0594c09780adaaa41fe60b1869ba41c8905a0c98:24a8102d6795963b77f04bb83cc82c081e4a2adc-0' }"
+
+    input:
+    path customfilters
+
+    output:
+    env tagargs          , emit: tagargs
+    path "versions.yml"  , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+
+    """
+    tagargs=\$(create_vembrane_tags.py \\
+        --filterdefinitions $customfilters \\
+        $args)
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+}

--- a/modules/local/vembrane/filter/main.nf
+++ b/modules/local/vembrane/filter/main.nf
@@ -1,0 +1,51 @@
+process VEMBRANE_FILTER {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "bioconda::vembrane=1.0.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/vembrane:1.0.1--pyhdfd78af_0':
+        'quay.io/biocontainers/vembrane:1.0.1--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(vcf)
+    each filter
+
+    output:
+    tuple val(filtmeta), path("*.vcf") , emit: vcf
+    path "versions.yml"                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    filtmeta = [:]
+    filtmeta.id = "${meta.id}_${filter}"
+
+    """
+    vembrane filter \\
+        --output ${prefix}_${filter}.vcf \\
+        $args \\
+        '"$filter" in FILTER' \\
+        $vcf
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        vembrane: \$(echo \$(vembrane --version 2>&1) | sed 's/^.*vembrane //; s/Using.*\$//' ))
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.vcf
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        vembrane: \$(echo \$(vembrane --version 2>&1) | sed 's/^.*vembrane //; s/Using.*\$//' ))
+    END_VERSIONS
+    """
+
+}

--- a/modules/local/vembrane/tag/main.nf
+++ b/modules/local/vembrane/tag/main.nf
@@ -1,0 +1,50 @@
+process VEMBRANE_TAG {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "bioconda::vembrane=1.0.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/vembrane:1.0.1--pyhdfd78af_0':
+        'quay.io/biocontainers/vembrane:1.0.1--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(vcf)
+    val tagargs
+
+    output:
+    tuple val(meta), path("*.vcf"), emit: vcf
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    vembrane tag \\
+        --output ${prefix}_tag.vcf \\
+        --output-fmt vcf \\
+        $tagargs \\
+        $args \\
+        $vcf
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        vembrane: \$(echo \$(vembrane --version 2>&1) | sed 's/^.*vembrane //; s/Using.*\$//' ))
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.vcf
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        vembrane: \$(echo \$(vembrane --version 2>&1) | sed 's/^.*vembrane //; s/Using.*\$//' ))
+    END_VERSIONS
+    """
+
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,9 +32,11 @@ params {
     // Bedfile options
     bedfile			= null
 
-    // Transcript filtering
+    // Filtering
     transcriptfilter            = null
     transcriptlist              = []
+    custom_filters              = null
+    used_filters                = null
 
     // VEP options
     vep                         = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -230,6 +230,18 @@
                     "help_text": "If variant does not have any match, all annotation will be removed and variant is flagged in FILTER column.\nCan work simultaneously with \"transcriptfilter\" param.",
                     "format": "file-path",
                     "description": "List of transcripts for filtering."
+                },
+                "custom_filters": {
+                    "type": "string",
+                    "default": "None",
+                    "description": "TSV file defining custom filters for VCF files. VCF files will be tagged with those filters in the FILTER column.",
+                    "help_text": "The TSV files needs two columns: The first column contains the name of the filter (letters, numbers and underscores allowed), the second column a valid python expression defining the filter. The python expression has to follow the guidelines for vembrane, also see here: https://github.com/vembrane/vembrane#filter-expression. An example can be found in assets/custom_filters.tsv."
+                },
+                "used_filters": {
+                    "type": "string",
+                    "default": "None",
+                    "description": "Define which filters from `custom_filters` will be used to subset VCF files and create separate TSV and HTML files.",
+                    "help_text": "Needs to match the filter name from `custom_filters`. Multiple filters can be defined (space-separated), but not combined."
                 }
             }
         },

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -20,7 +20,7 @@ workflow INPUT_CHECK {
     versions = SAMPLESHEET_CHECK.out.versions    // channel: [ versions.yml ]
 }
 
-// Function to get list of [ meta, [ fastq_1, fastq_2 ] ]
+// Function to get list of [ meta, vcf ]
 def create_vcf_channel(LinkedHashMap row) {
     // create meta map
     def meta = [:]

--- a/subworkflows/local/variantfilter/main.nf
+++ b/subworkflows/local/variantfilter/main.nf
@@ -1,0 +1,44 @@
+//
+// Tag VCF file with predefined filters.
+//
+
+include { VEMBRANE_CREATE_TAGS } from '../../../modules/local/vembrane/create-vembrane-tags/main'
+include { VEMBRANE_TAG         } from '../../../modules/local/vembrane/tag/main'
+include { VEMBRANE_FILTER      } from '../../../modules/local/vembrane/filter/main'
+
+
+workflow VARIANTFILTER {
+    take:
+    vcf                 // channel: [ val(meta), vcf ]
+    predefined_filters  // path: TSV file with predefined filters
+
+    main:
+    ch_versions = Channel.empty()
+
+    // create once vembrane tag argument from custom filters
+    VEMBRANE_CREATE_TAGS (predefined_filters)
+    ch_versions = ch_versions.mix(VEMBRANE_CREATE_TAGS.out.versions)
+
+    // convert vembrane tag command to value channel for reusing it in each vcf
+    ch_filtercmd = VEMBRANE_CREATE_TAGS.out.tagargs.first()
+
+    // tag vcf files with custom filters
+    VEMBRANE_TAG (  vcf,
+                    ch_filtercmd
+    )
+    ch_versions = ch_versions.mix(VEMBRANE_TAG.out.versions)
+
+    // split VCF files by used filters
+    ch_filters = Channel.of(params.used_filters.split())
+    VEMBRANE_FILTER(VEMBRANE_TAG.out.vcf,
+                    ch_filters
+    )
+    ch_versions = ch_versions.mix(VEMBRANE_FILTER.out.versions)
+
+    // merge channels with unfiltered and filtered VCF files to create HTML report for each of them
+    allvcfs = VEMBRANE_FILTER.out.vcf.concat(VEMBRANE_TAG.out.vcf)
+
+    emit:
+    vcf      =   allvcfs          // channel: [ val(meta), .vcf ]
+    versions =   ch_versions      // path: versions.yml
+}


### PR DESCRIPTION
# Implements custom, predefined filters

This PR adds a new feature that allows the usage of more complex filter definitions for VCF files as discussed in issue #21 .

1. `vembrane tag` tags variants by specific filter criteria within the FILTER column of the VCF files.
The parameter `--custom_filters` controls this feature. It specified a TSV file, for which an example is deposited in [assets/custom_filters.tsv](assets/custom_filters.tsv), that has information about filter names and their respective filter criteria. It can follow python syntax as specified for vembrane filter (see also [vembrane docs](https://github.com/vembrane/vembrane#filter-expression)). All filters specified here will be tagged in the VCF file.

3. `vembrane filter` creates additional VCF file with variants filtered based on the specific filter.
The parameter `--used_filters` controls this feature. It accepts filter names present in the FILTER column of the VCF file. It will create additional VCF files with the respective FILTER subset (i.e., **_including_** all variants with the respective tag) that will be further processed downstream, generating separate TSV and HTML files. the unfiltered VCF will also be provided, i.e. this filter does not prevent the output of full VCF file reports.

Future goals:
- Enable combining filters more easily, e.g. by just defining "pathogenic and high_quality" or "BRCAgenes or EMTgenes" 