### PR TITLE
Add read_depth as separate parameter for TSV conversion.

### DIFF
--- a/bin/create_vembrane_fields.py
+++ b/bin/create_vembrane_fields.py
@@ -40,8 +40,13 @@ def parse_arguments():
     )
     parser.add_argument(
         "--allele_fraction",
-        help="Add here how to calculate allele_fraction. Only allows values: FORMAT_AF, FORMAT_AD, mutect2, freebayes ",
+        help="Specify here how to calculate allele_fraction. Only allows values: FORMAT_AF, FORMAT_AD, mutect2, freebayes.",
         choices=["FORMAT_AF", "FORMAT_AD", "mutect2", "freebayes"],
+        type=str,
+    )
+    parser.add_argument(
+        "--read_depth",
+        help='Specify here from which FORMAT field to extract read depth. The column will always be named "read_depth" for downstream compatibility.',
         type=str,
     )
     parser.add_argument(
@@ -132,6 +137,11 @@ if __name__ == "__main__":
             header_strings.append("allele_fraction")
         else:
             raise ValueError("ERROR: Did not specify correct allele_fraction.")
+
+    # add read depth
+    if args.read_depth:
+        vembrane_strings.append('FORMAT["' + str(args.read_depth) + '"][' + str(args.sampleindex) + "]")
+        header_strings.append("read_depth")
 
     if args.format_fields:
         # Formatting the FORMAT fields.

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -76,6 +76,7 @@ process {
         ext.args = { [
             '--other_fields CHROM,POS,ID,REF,ALT,QUAL,FILTER',
             (params.allele_fraction)        ? "--allele_fraction ${params.allele_fraction}" : '',
+            (params.read_depth)             ? "--read_depth ${params.read_depth}"           : '',
             (params.format_fields)          ? "--format_fields ${params.format_fields}"     : '',
             (params.info_fields)            ? "--info_fields ${params.info_fields}"         : '',
             '--sampleindex 0',

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,8 +52,9 @@ params {
     // Vembrane table options
     tsv                         = true
     allele_fraction             = 'FORMAT_AD'
+    read_depth                  = 'DP'
     annotation_fields           = 'all'
-    format_fields               = 'GT AD[0] AD[1] DP'
+    format_fields               = 'GT AD[0] AD[1]'
     info_fields                 = null
 
     // HTML report options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -223,6 +223,11 @@
                     "help_text": "The allele fraction (AF) of a variant is not always reported directly in the VCF file, but encoded indirectly in the FORMAT column. The AF is extracted or calculated  in the `vembrane table` module.   \nWithin the FORMAT column are some standard fields from which the AF can be calculated:   \n\n- **DP:** Depth or coverage, number of reads at this position.  \n- **AD:** Allelic depth, Number of reads supporting REF and ALT alleles (comma-separated, can be addressed with [0] or [1] as index)  \n\nDividing the allelic depth by the coverage gives the AF, which can be invoked with `FORMAT_AD`. Some VCF files also directly encode the AF in the FORMAT column as `AF` field, which can be invoked with `FORMAT_AF`.  \nFor the following variant callers, some defaults were specified that can be invoked by the name of the caller:  \n\n- **Freebayes** uses the `FORMAT_AD` method dividing ALT allele readnumbers (AD[1]) by depth (DP)   \n- **Mutect2** uses the AF field in the FORMAT column as defined in `FORMAT_AF` method. It is a probabilistic AF estimate, hence it is different compared to AF calculated with DP and AD column. Additionally, the DP field is also in the INFO column and will be extracted, which can be greater as the DP field in the FORMAT column as it also contains uninformative reads. So there can be three different ways of calculating the AF. Sources: [[1]](https://gatk.broadinstitute.org/hc/en-us/community/posts/4566282375835-Mutect2-AF-does-not-match-AD-and-DP),[[2]](https://github.com/broadinstitute/gatk/issues/6067),[[3]](https://gatk.broadinstitute.org/hc/en-us/articles/360035532252-Allele-Depth-AD-is-lower-than-expected). ",
                     "enum": ["FORMAT_AF", "mutect2", "FORMAT_AD", "freebayes"]
                 },
+                "read_depth": {
+                    "type": "string",
+                    "default": "DP",
+                    "description": "Specify from which FORMAT field to extract read depth.  This will specify the column named \"read_depth\" in the output report and TSV file.."
+                },
                 "annotation_fields": {
                     "type": "string",
                     "default": "all",


### PR DESCRIPTION
Very small PR that appends to PR #28.
Similarly to the allele fraction I added a parameter for the read_depth to specify this field from the VCF FORMAT column.
This enables having the same header name "read_depth" for all downstream processes, as this parameter is important and needed for example for TMB calculation. Also gives the flexibility to change this field if named different, but keeping 'DP" as default.
This is simultaneous to the allele_fraction parameter and hence works well with my local tests.

