### PR TITLE
Fixed Samtools dict from getSimpleName to getBaseName

### DIFF
--- a/modules/nf-core/samtools/dict/main.nf
+++ b/modules/nf-core/samtools/dict/main.nf
@@ -19,7 +19,7 @@ process SAMTOOLS_DICT {
 
     script:
     def args = task.ext.args ?: ''
-    def dict = fasta.getSimpleName()
+    def dict = fasta.getBaseName()
     """
     samtools \\
         dict \\

--- a/modules/nf-core/samtools/dict/samtools-dict.diff
+++ b/modules/nf-core/samtools/dict/samtools-dict.diff
@@ -5,7 +5,7 @@ Changes in module 'nf-core/samtools/dict'
  
      script:
      def args = task.ext.args ?: ''
-+    def dict = fasta.getSimpleName()
++    def dict = fasta.getBaseName()
      """
      samtools \\
          dict \\


### PR DESCRIPTION
Fixed bug with `samtools dict`: It produced an error with FASTA files having dots within the filename and not only as suffix. changed from "getSimpleName" to "getBaseName" java function for fixing.