### PR TITLE
Support multi-sample VCF files as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## dev
+
+### Added
+
+- support multi-sample VCF files according to issue #35
+
 ## v1.0.0 - [24th October 2023]
 
 Initial release of variantinterpretation pipeline, created with the [nf-core](https://nf-co.re/) template.

--- a/assets/custom_filters.tsv
+++ b/assets/custom_filters.tsv
@@ -1,4 +1,4 @@
 name	filter
-high_qual	FORMAT["DP"][0] > 100 and (FORMAT["AD"][0][1] / FORMAT["DP"][0]) > 0.02
+high_qual	any(FORMAT["DP"][s] > 100 for s in SAMPLES)
 pathogenic	not {"pathogenic","likely_pathogenic","drug_response"}.isdisjoint(CSQ["CLIN_SIG"])
 BRCAgenes	CSQ["SYMBOL"] in {"BRCA2","BRCA1"}

--- a/bin/check_vcf.py
+++ b/bin/check_vcf.py
@@ -71,9 +71,7 @@ def parse_arguments():
 def read_vcf(vcf_in):
     vcffile = pd.read_csv(vcf_in, sep="\t", comment="#", header=None)
     if len(vcffile.columns) < 10:
-        raise ValueError(
-            "ERROR: Your VCF file has less than 10 columns and may miss columns."
-        )
+        raise ValueError("ERROR: Your VCF file has less than 10 columns and may miss columns.")
     else:
         vcffile.columns = [
             "CHROM",
@@ -85,7 +83,7 @@ def read_vcf(vcf_in):
             "FILTER",
             "INFO",
             "FORMAT",
-        ] + ['SAMPLE{}'.format(i) for i in range(1, len(vcffile.columns) - 8)]
+        ] + ["SAMPLE{}".format(i) for i in range(1, len(vcffile.columns) - 8)]
     return vcffile
 
 

--- a/bin/check_vcf.py
+++ b/bin/check_vcf.py
@@ -35,11 +35,6 @@ def parse_arguments():
         action="store_true",
     )
     parser.add_argument(
-        "--check_single_sample",
-        help="Check if provided VCF only contains a single sample.",
-        action="store_true",
-    )
-    parser.add_argument(
         "--check_MNPs",
         help="Check if provided VCF contains multinucleotide variants.",
         action="store_true",
@@ -75,9 +70,9 @@ def parse_arguments():
 
 def read_vcf(vcf_in):
     vcffile = pd.read_csv(vcf_in, sep="\t", comment="#", header=None)
-    if len(vcffile.columns) != 10:
+    if len(vcffile.columns) < 10:
         raise ValueError(
-            "ERROR: Your VCF file has more than 10 columns. Perhaps you submitted a multi-sample VCF file?"
+            "ERROR: Your VCF file has less than 10 columns and may miss columns."
         )
     else:
         vcffile.columns = [
@@ -90,8 +85,7 @@ def read_vcf(vcf_in):
             "FILTER",
             "INFO",
             "FORMAT",
-            "SAMPLE",
-        ]
+        ] + ['SAMPLE{}'.format(i) for i in range(1, len(vcffile.columns) - 8)]
     return vcffile
 
 
@@ -254,18 +248,6 @@ if __name__ == "__main__":
         report_message = report_message + [check_FILTERs(vcffile, meta_id=args.meta_id, log_level="WARNING")]
 
     # Input checks based on bcftools stats output.
-    if args.check_single_sample:
-        report_message = report_message + [
-            check_stats_value(
-                args.bcftools_stats_in,
-                pattern="number of samples",
-                textsnippet="samples. The workflow only accepts single-sample VCFs",
-                intcheck=1,
-                meta_id=args.meta_id,
-                log_level="ERROR",
-            )
-        ]
-
     if args.check_MNPs:
         report_message = report_message + [
             check_stats_value(

--- a/bin/create_vembrane_fields.py
+++ b/bin/create_vembrane_fields.py
@@ -129,17 +129,17 @@ if __name__ == "__main__":
     if args.allele_fraction:
         if args.allele_fraction in ["mutect2", "FORMAT_AF"]:
             vembrane_strings.append('for_each_sample(lambda s: FORMAT["AF"][s])')
-            header_strings.append('for_each_sample(lambda sample: f"{sample}_allele_fraction")')
+            header_strings.append('for_each_sample(lambda sample: f"allele_fraction{sample}")')
         elif args.allele_fraction in ["freebayes", "FORMAT_AD"]:
             vembrane_strings.append('for_each_sample(lambda s: FORMAT["AD"][s][1]/FORMAT["DP"][s])')
-            header_strings.append('for_each_sample(lambda sample: f"{sample}_allele_fraction")')
+            header_strings.append('for_each_sample(lambda sample: f"allele_fraction{sample}")')
         else:
             raise ValueError("ERROR: Did not specify correct allele_fraction.")
 
     # add read depth
     if args.read_depth:
         vembrane_strings.append('for_each_sample(lambda s: FORMAT["' + str(args.read_depth) + '"][s])')
-        header_strings.append('for_each_sample(lambda sample: f"{sample}_read_depth")')
+        header_strings.append('for_each_sample(lambda sample: f"read_depth{sample}]")')
 
     if args.format_fields:
         # Formatting the FORMAT fields.

--- a/bin/create_vembrane_fields.py
+++ b/bin/create_vembrane_fields.py
@@ -85,9 +85,9 @@ def formatting_field(
         # formatting fields for vembrane input
         only_field_formatted = f'{column_name}["{only_field}"]'
 
-        #add sample index fields
+        # add sample index fields
         if all_samples:
-            header_field += '[{sample}]'
+            header_field += "[{sample}]"
             only_field_formatted += "[s]"
 
         # replace from original field; this preserves brackets and numbers from the input.

--- a/bin/preprocess_datavzrd.py
+++ b/bin/preprocess_datavzrd.py
@@ -128,7 +128,6 @@ def check_for_duplicates(strings_list, listname):
 
 
 def duplicate_rows_with_pattern(variant_df, colinfo_df, matched_colname, ann_name_column, ann_label_column):
-
     # Find columns in variant_df that match the pattern
     # for format fields we may have the case of subsets, like FORMAT_AD[1] in the columns name.
     # since the sample is in between (FORMAT_AD[sample][1]), we need special matching then
@@ -175,7 +174,6 @@ def duplicate_rows_with_pattern(variant_df, colinfo_df, matched_colname, ann_nam
 
 
 def match_patterns_and_duplicate(variant_df, colinfo_df, pattern, ann_name_column, ann_label_column):
-
     # Get colnames matching the pattern
     matched_colnames = [id for id in colinfo_df[ann_name_column] if re.search(pattern, id)]
     if len(matched_colnames) < 1:

--- a/conf/modules/preprocess.config
+++ b/conf/modules/preprocess.config
@@ -59,7 +59,6 @@ process {
         ]
         ext.args = { [
             '--check_chr_prefix',
-            '--check_single_sample',
             '--check_vep_annotation',
             '--check_MNPs',
             '--check_gVCF',

--- a/conf/modules/report.config
+++ b/conf/modules/report.config
@@ -36,7 +36,6 @@ process {
             (params.read_depth)             ? "--read_depth ${params.read_depth}"           : '',
             (params.format_fields)          ? "--format_fields ${params.format_fields}"     : '',
             (params.info_fields)            ? "--info_fields ${params.info_fields}"         : '',
-            '--sampleindex 0',
         ].join(' ').trim() }
     }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,13 +1,10 @@
 # cio-abcd/variantinterpretation: Usage
 
-:::note
-If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/usage/installation) on how
-to set-up Nextflow.
+> NOTE: If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/usage/installation) on how
+> to set-up Nextflow.
 
 <!-- Make sure to [test your setup](https://nf-co.re/docs/usage/introduction#how-to-run-a-pipeline)
 with `-profile test` before running the workflow on actual data. -->
-
-:::
 
 ## Introduction
 
@@ -63,9 +60,7 @@ This version number will be logged in reports when you run the pipeline, so that
 
 To further assist in reproducbility, you can use share and re-use [parameter files](#running-the-pipeline) to repeat pipeline runs with the same settings without having to write out a command with every single parameter.
 
-:::tip
-If you wish to share such profile (such as upload as supplementary material for academic publications), make sure to NOT include cluster specific paths to files, nor institutional specific profiles.
-:::
+> TIP: If you wish to share such profile (such as upload as supplementary material for academic publications), make sure to NOT include cluster specific paths to files, nor institutional specific profiles.
 
 ### Download reference files
 
@@ -153,9 +148,7 @@ It is highly recommended to define these parameters with
 nf-core launch -ax vio-abcd/variantinterpretation
 ```
 
-:::note
-The flags `-a` saves all parameters, even defaults, for better reproducibility and `-x` also shows hidden parameters.
-:::
+**NOTE: The flags `-a` saves all parameters, even defaults, for better reproducibility and `-x` also shows hidden parameters.**
 
 It opens a web-based interface to define the parameters showing helpful descriptions, default values and constraints for each parameter. You can also find the description of parameters in [docs/params.md](../docs/params.md) and lots of additional information in the [README.md](../README.md).
 
@@ -171,16 +164,9 @@ nextflow run cio-abcd/variantinterpretation \
     --vep_cache $HOME/.vep
 ```
 
-:::note
-The `--vep_cache` parameter needs to be defined in the `nextflow run` command and _not_ within the nf-params.json file.
-If using the igenomes resource, the `--igenomes_base` parameter also needs to be specified in the `nextflow run` command and not in the `nf-params.json` file.
-:::
+> NOTE: The `--vep_cache` parameter needs to be defined in the `nextflow run` command and _not_ within the nf-params.json file. If using the igenomes resource, the `--igenomes_base` parameter also needs to be specified in the `nextflow run` command and not in the `nf-params.json` file.
 
-:::warning
-Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those
-provided by the `-c` Nextflow option can be used to provide any configuration _**except for parameters**_;
-see [docs](https://nf-co.re/usage/configuration#custom-configuration-files).
-:::
+> WARNING: Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those provided by the `-c` Nextflow option can be used to provide any configuration _**except for parameters**_; see [docs](https://nf-co.re/usage/configuration#custom-configuration-files).
 
 The pipeline will create the following files in your working directory:
 


### PR DESCRIPTION
This PR addresses Issue #35 for supporting multi-sample VCF files.

The following changes were made:
- removed the check for single_samples in vcf_check.py
- changed create_vembrane_fields.py to automatically parse samples in vcf. This makes use of the "for_each_sample()" function implemented in vembrane. All fields specified in the parameters that affect the FORMAT fields are done for each sample in teh vcf and included into the reports with the VCF-internal sample name incorporated into the column name.
- Changed documentation accordingly and fixed minor formatting and spelling errors.