### PR TITLE
enhance modularity of variantinterpretation workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - support merging of vcf files according to issue #36
 - updated nf-core modules
 
+### Changed
+
+- moved scripts from bin/ to their respective module/resources/usr/bin
+- factored out VARIANTINTERPRETATION_CORE without MULTIQC from VARIANTINTERPRETATION workflow
+
 ### `Fixed`
 
 - fixed vembrane error by updating vembrane to 1.0.6 (Issue #46)

--- a/main.nf
+++ b/main.nf
@@ -15,7 +15,7 @@ nextflow.enable.dsl = 2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { VARIANTINTERPRETATION   } from './workflows/variantinterpretation'
+include { VARIANTINTERPRETATION; MULTIQC_REPORT   } from './workflows/variantinterpretation'
 include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_variantinterpretation_pipeline'
 include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_variantinterpretation_pipeline'
 include { getGenomeAttribute      } from './subworkflows/local/utils_nfcore_variantinterpretation_pipeline'
@@ -92,8 +92,18 @@ workflow CIOABCD_VARIANTINTERPRETATION {
         ch_custom_filters
     )
 
+    ch_versions = VARIANTINTERPRETATION.out.ch_versions
+    ch_multiqc_files = VARIANTINTERPRETATION.out.ch_multiqc_files
+    ch_warnings = VARIANTINTERPRETATION.out.ch_warnings
+
+    MULTIQC_REPORT (
+        ch_versions,
+        ch_multiqc_files,
+        ch_warnings,
+    )
+
     emit:
-    multiqc_report = VARIANTINTERPRETATION.out.multiqc_report // channel: /path/to/multiqc_report.html
+    multiqc_report = MULTIQC_REPORT.out.multiqc_report // channel: /path/to/multiqc_report.html
 
 }
 /*

--- a/modules/local/datavzrd/preprocess/resources/usr/bin/preprocess_datavzrd.py
+++ b/modules/local/datavzrd/preprocess/resources/usr/bin/preprocess_datavzrd.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python
+
+import argparse
+import pandas as pd
+import numpy as np
+import yte
+import re
+
+
+def parse_arguments():
+    # Create argument parser
+    parser = argparse.ArgumentParser(
+        description="Split variant TSV file by groups and create datavzrd config file."
+    )
+    parser.add_argument(
+        "--variant_tsv",
+        type=str,
+        help="File path to TSV file with variant information.",
+    )
+    parser.add_argument(
+        "--colinfo_tsv",
+        type=str,
+        help="File path to TSV file with information about annotation columns in variant_tsv.",
+    )
+    parser.add_argument(
+        "--ann_name_column",
+        type=str,
+        help="Column name in colinfo_tsv containing the column names of variant_tsv.",
+        default="identifier",
+    )
+    parser.add_argument(
+        "--ann_group_column",
+        type=str,
+        help="Column name in colinfo_tsv containing the group information of column names of variant_tsv, in which TSVs should be split.",
+        default="group",
+    )
+    parser.add_argument(
+        "--ann_label_column",
+        type=str,
+        help="Column name in colinfo_tsv containing the label information of column names of variant_tsv, that gives the name in the HTML report.",
+        default="label",
+    )
+    parser.add_argument(
+        "--identifiers",
+        type=str.lower,
+        nargs="+",
+        help="Column names used for creating an identifier for each split TSV file, used for referencing links between them. Space-separated",
+        default=["chrom", "pos", "ref", "alt", "id", "feature"],
+    )
+    parser.add_argument(
+        "--prefix", type=str, help="prefix for sample to distinguish them."
+    )
+    parser.add_argument(
+        "--datavzrd_template",
+        type=str,
+        help="Path to datavzrd config template that will be rendered.",
+    )
+
+    # Parse command-line arguments
+    return parser.parse_args()
+
+
+def process_ann_cols(
+    variant_df,
+    colinfo_df,
+    ann_name_column,
+    ann_group_column,
+    identifiers,
+    id_name,
+    ann_label_column,
+):
+    ### Processing of column names for matching colinfo table ###
+    # removing CSQ prefixes from column names
+    variant_df.columns = variant_df.columns.str.replace("CSQ_", "")
+
+    # for case-insensitive matching of variant TSV columns and colinfo: convert both to lower strings
+    variant_df.columns = variant_df.columns.str.lower()
+    colinfo_df[ann_name_column] = colinfo_df[ann_name_column].str.lower()
+
+    # replace mathematical operands and brackets with their literal names in variant TSV column names (compatibility with datavzrd)
+    # brackets are replaced with "-"
+    variant_df.columns = replace_operands(variant_df.columns)
+
+    # check for characters beyond letters, numbers and underscores in column names
+    input_check(variant_df.columns, r"^[A-Za-z0-9_\-]+$")
+    input_check(colinfo_df[ann_name_column], r"^[A-Za-z0-9_\-]+$")
+
+    # check for duplicated variant TSV columns or column info.
+    check_for_duplicates(variant_df.columns, "variant TSV file column names")
+    check_for_duplicates(
+        colinfo_df[ann_name_column], "colinfo TSV file annotation name column"
+    )
+
+    # Here we check for colinfo columns that are sample-specific and duplicate them based on the sample names
+    colinfo_df = match_patterns_and_duplicate(
+        variant_df, colinfo_df, "read_depth", ann_name_column, ann_label_column
+    )
+    colinfo_df = match_patterns_and_duplicate(
+        variant_df, colinfo_df, "allele_fraction", ann_name_column, ann_label_column
+    )
+    colinfo_df = match_patterns_and_duplicate(
+        variant_df, colinfo_df, "format", ann_name_column, ann_label_column
+    )
+
+    # Compare TSV files and add columns that are missing
+    variant_df, colinfo_df = add_missing_columns(
+        variant_df, colinfo_df, ann_name_column, ann_group_column
+    )
+
+    # Create a column with pasted identifiers as an ID column that will be used to reference variants between tables.
+    variant_df = generate_variant_ids(variant_df, id_name, identifiers)
+
+    return variant_df, colinfo_df
+
+
+# replace operands with literal names
+def replace_operands(df_index):
+    operator_replacements = {
+        "+": "-plus-",
+        "-": "-minus-",
+        "*": "-times-",
+        "/": "-divided-by-",
+        "%": "-modulus-",
+        "[": "-",
+        "]": "-",
+    }
+    replace_pattern = r"[-+*/%\[\]]"
+    return df_index.str.replace(
+        replace_pattern, lambda m: operator_replacements[m.group()], regex=True
+    )
+
+
+# check if string matches regular expression
+def input_check(input_strings, regex):
+    for input_string in input_strings:
+        if re.fullmatch(regex, input_string) is None:
+            raise ValueError(
+                f'Error: The annotation name "{input_string}" should match regex "{regex}".'
+            )
+
+
+# check list of strings for duplicates and give error message with all duplicated entries.
+def check_for_duplicates(strings_list, listname):
+    seen = set()
+    duplicates = set()
+
+    for string in strings_list:
+        if string in seen:
+            duplicates.add(string)
+        else:
+            seen.add(string)
+
+    if duplicates:
+        duplicate_entries = ", ".join(duplicates)
+        raise ValueError(
+            f"Found duplicate entries in the {listname}: {duplicate_entries}"
+        )
+
+
+def duplicate_rows_with_pattern(
+    variant_df, colinfo_df, matched_colname, ann_name_column, ann_label_column
+):
+    # Find columns in variant_df that match the pattern
+    # for format fields we may have the case of subsets, like FORMAT_AD[1] in the columns name.
+    # since the sample is in between (FORMAT_AD[sample][1]), we need special matching then
+
+    matched_rows = []
+    samplenames = []
+    if matched_colname.startswith("format") and matched_colname.endswith("-"):
+        for col in variant_df.columns:
+            prefix = matched_colname.split("-")[0]
+            number = matched_colname.split("-")[-2]
+            if col.startswith(prefix) and col.endswith(f"-{number}-"):
+                matched_rows.append(col)
+                samplenames.append(
+                    col.replace(prefix, "").replace(f"-{number}-", "").strip("-")
+                )
+    else:
+        for col in variant_df.columns:
+            if re.search(matched_colname, col):
+                matched_rows.append(col)
+                samplenames.append(col.replace(matched_colname, "").strip("-"))
+
+    matching_rows_for_colname = colinfo_df[
+        colinfo_df[ann_name_column] == matched_colname
+    ]
+
+    # Get the index of the matching row
+    match_index = matching_rows_for_colname.index[0]
+
+    # Duplicate the matching row for each column in variant_df that matches the pattern
+    new_rows = []
+    for col, samplename in zip(matched_rows, samplenames):
+        new_row = colinfo_df.loc[match_index].copy()
+        new_row[ann_name_column] = col
+        new_row[ann_label_column] = new_row[ann_label_column] + " " + samplename
+        new_rows.append(new_row)
+
+    # Create a new DataFrame from the new rows
+    new_colinfo_df = pd.DataFrame(new_rows)
+
+    # Insert the new rows back into the original colinfo_df at the correct position
+    colinfo_df = colinfo_df.drop(match_index).reset_index(drop=True)
+    new_colinfo_df.index = [match_index] * len(new_colinfo_df)
+    result_colinfo_df = pd.concat(
+        [colinfo_df.iloc[:match_index], new_colinfo_df, colinfo_df.iloc[match_index:]]
+    ).reset_index(drop=True)
+
+    return result_colinfo_df
+
+
+def match_patterns_and_duplicate(
+    variant_df, colinfo_df, pattern, ann_name_column, ann_label_column
+):
+    # Get colnames matching the pattern
+    matched_colnames = [
+        id for id in colinfo_df[ann_name_column] if re.search(pattern, id)
+    ]
+    if len(matched_colnames) < 1:
+        raise ValueError(
+            f'There must be at least one entry matching "{pattern}" in the "{ann_name_column}".'
+        )
+
+    # Loop through each of the colnames and duplicate rows
+    for matched_colname in matched_colnames:
+        colinfo_df = duplicate_rows_with_pattern(
+            variant_df, colinfo_df, matched_colname, ann_name_column, ann_label_column
+        )
+
+    return colinfo_df
+
+
+def add_missing_columns(variant_df, colinfo_df, ann_name_column, ann_group_column):
+    # Get column names from variant_tsv and colinfo_tsv
+    variant_cols = set(variant_df.columns)
+    colinfo_cols = set(colinfo_df[ann_name_column])
+
+    # Find columns in colinfo_df that are missing in variant_df
+    missing_columns = colinfo_cols - variant_cols
+
+    if missing_columns:
+        print(
+            "Warning: The following columns are missing in variant tsv file but are present in colinfo tsv file and will be added with empty values:"
+        )
+        for column in missing_columns:
+            print(f"- {column}")
+            # Add missing columns to variant_tsv with nan values
+            variant_df[column] = np.nan
+
+    # Find columns in variant_tsv that are not defined in colinfo_tsv
+    undefined_columns = variant_cols - colinfo_cols
+
+    if undefined_columns:
+        print(
+            f"Warning: Columns present in variant tsv file but not defined in colinfo tsv file."
+        )
+        print("These columns will be included in the 'others' group.")
+        for column in undefined_columns:
+            print(f"  - {column}")
+            # Add new row to colinfo_tsv with "nan" values, 'others' group, same label and normal display mode.
+            new_rows = pd.DataFrame(
+                [[column, "others", column, "normal"]],
+                columns=[ann_name_column, ann_group_column, "label", "display"],
+            )
+            colinfo_df = pd.concat([colinfo_df, new_rows])
+
+    return variant_df, colinfo_df
+
+
+# generate a minus-linked string from multiple columns
+def generate_variant_ids(variant_df, id_name, identifiers):
+    variant_df[id_name] = variant_df[identifiers].apply(
+        lambda x: "-".join(x.astype(str)), axis=1
+    )
+    return variant_df
+
+
+# split the variant dataframe by groups
+def split_df_by_group(
+    colinfo_df,
+    variant_df,
+    group,
+    ann_name_column,
+    ann_group_column,
+    identifiers,
+    id_name,
+    prefix,
+):
+    # Extract which columns are in a group
+    group_cols = colinfo_df.query(ann_group_column + "=='" + group + "'")[
+        ann_name_column
+    ]
+    # also add identifiers
+    group_cols = [id_name] + identifiers + list(group_cols)
+    # avoid having identifiers duplicated, so remove duplicates
+    group_cols = list(dict.fromkeys(group_cols))
+    # subset the variant_df based on this list, with identifier columns always in front.
+    group_df = variant_df[group_cols]
+    # save as tsv file
+    group_df.to_csv(prefix + "-" + group + ".tsv", sep="\t", index=False)
+
+
+# convert a string with comma-separated key-value pairs to a dictionary
+def convert_to_dict(string, delimiter):
+    # split multiple comma-separated key:value pairs
+    pairs = re.split(",", string)
+    # split keys and values by equal sign and format to dictionary
+    return {key: value for key, value in (re.split(delimiter, pair) for pair in pairs)}
+
+
+# process colinfo columns and provide them in datavzrd rendering
+def render_datavzrd_config(
+    colinfo_df, datavzrd_template, ann_group_column, ann_name_column, prefix
+):
+    # get set of groups from file
+    groups = set(colinfo_df[ann_group_column])
+
+    # get all column names from specific group
+    def get_group_cols(colinfo_df, ann_group_column, group, ann_name_column):
+        return list(
+            colinfo_df.query(ann_group_column + "=='" + group + "'")[ann_name_column]
+        )
+
+    # create a dictionary with all groups and columns and pass to yaml template
+    yaml_variables = {
+        "prefix": prefix,
+        "groupnames": groups,
+        "colnames": dict(
+            zip(
+                groups,
+                [
+                    get_group_cols(colinfo_df, ann_group_column, group, ann_name_column)
+                    for group in groups
+                ],
+            )
+        ),
+    }
+    for col in colinfo_df.keys():
+        yaml_variables.update(
+            {col: dict(zip(colinfo_df[ann_name_column], colinfo_df[col]))}
+        )
+
+    # convert strings from data_type_value column that contain 'key1=value1,key2=value2,[...] to dictionaries
+    for dtv_key in yaml_variables["data_type_value"].keys():
+        if not pd.isna(yaml_variables["data_type_value"][dtv_key]):
+            yaml_variables["data_type_value"][dtv_key] = convert_to_dict(
+                yaml_variables["data_type_value"][dtv_key], "="
+            )
+
+    # render yaml template with yte and save as separate config file
+    with open(datavzrd_template, "r") as template, open(
+        prefix + "-datavzrd-config-rend.yaml", "w"
+    ) as outfile:
+        result = yte.process_yaml(template, outfile=outfile, variables=yaml_variables)
+
+
+if __name__ == "__main__":
+    # Parse command-line arguments
+    args = parse_arguments()
+
+    # Read variant TSV file that will be processed
+    variant_df = pd.read_csv(args.variant_tsv, sep="\t")
+    # Load annotation column database used for referencing information
+    colinfo_df = pd.read_csv(args.colinfo_tsv, sep="\t")
+
+    # Since integer columns are by default not read correctly if empty values are there, convert dtypes before proceeding
+    variant_df = variant_df.convert_dtypes()
+    colinfo_df = colinfo_df.convert_dtypes()
+
+    # Processing TSV file: column formatting + input checks
+    variant_df, colinfo_df = process_ann_cols(
+        variant_df,
+        colinfo_df,
+        args.ann_name_column,
+        args.ann_group_column,
+        args.identifiers,
+        "variant",
+        args.ann_label_column,
+    )
+
+    # Split variant_tsv by groups defined in colinfo_tsv and save as TSV files
+    for group in set(colinfo_df[args.ann_group_column]):
+        split_df_by_group(
+            colinfo_df,
+            variant_df,
+            group,
+            args.ann_name_column,
+            args.ann_group_column,
+            args.identifiers,
+            "variant",
+            args.prefix,
+        )
+
+    # render datavzrd config based on this groups
+    render_datavzrd_config(
+        colinfo_df,
+        args.datavzrd_template,
+        args.ann_group_column,
+        args.ann_name_column,
+        args.prefix,
+    )

--- a/modules/local/resources/bin/check_bedfiles.py
+++ b/modules/local/resources/bin/check_bedfiles.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+from pathlib import Path
+import sys
+import argparse
+import logging
+
+logger = logging.getLogger()
+
+### Set the values which could occur in a well structured bed file
+
+chroms = {
+    "chr1",
+    "chr2",
+    "chr3",
+    "chr4",
+    "chr5",
+    "chr6",
+    "chr7",
+    "chr8",
+    "chr9",
+    "chr10",
+    "chr11",
+    "chr12",
+    "chr13",
+    "chr14",
+    "chr15",
+    "chr16",
+    "chr17",
+    "chr18",
+    "chr19",
+    "chr20",
+    "chr21",
+    "chr22",
+    "chrX",
+    "chrY",
+    "chrM",
+}
+
+### Function to read in the input bed file
+
+
+def parse_args(argv=None):
+    """Define and immediately parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Validate the structure of the provided BED-sheet.",
+        epilog="Example: python3 check_bedfiles.py file.bed",
+    )
+    parser.add_argument(
+        "file_in",
+        metavar="FILE_IN",
+        type=Path,
+        help="File with .bed suffix.",
+    )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        help="The desired log level (default WARNING).",
+        choices=("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
+        default="WARNING",
+    )
+    return parser.parse_args(argv)
+
+
+### Function to check if the BED file provided can be used for bcftools and PyRanges
+
+
+def check_bed_structure(bed_input):
+    colcheck = pd.read_csv(bed_input, sep="\t", header=None)
+    header_test = any(
+        isinstance(value, str) for value in colcheck.iloc[0, 1:2]
+    )  ## checks for no full strings in positional argument columns, as chr is interpreted as str
+    if (
+        len(colcheck.columns) >= 3 and header_test == False
+    ):  ### Should contain at least three columns CHROM, POS, END without header
+        chrom_valid = check_chromosome_col(colcheck.iloc[:, 0])
+        start_valid = check_integer_col(colcheck.iloc[:, 1])
+        end_valid = check_integer_col(colcheck.iloc[:, 2])
+        order_check = check_startend_col(colcheck)
+        if chrom_valid == True:
+            if start_valid == True and end_valid == True and order_check == True:
+                return True
+            else:
+                return False
+        else:
+            return False
+    else:
+        logger.error(
+            "The provided BED file doesn't follow the required format. Please provide a BED file containing the minimal information (Chromosome, Start, End) without an header. TMB will not be calculated."
+        )
+        raise ValueError(
+            f"The provided BED file doesn't follow the required format. Please provide a BED file containing the minimal information (Chromosome, Start, End) without an header. TMB will not be calculated."
+        )
+
+
+def check_chromosome_col(input):
+    column = input.isin(chroms)
+    column_nonvalid_rows = column.index[column == False].tolist()
+    validity = column.all()
+    if validity == True:
+        logger.info("The Chromosome column is valid.")
+        return True
+    else:
+        logger.error(
+            'The Chromosome column contains values not following the "chr1-chr22/X/Y" convention. Please check the rows ',
+            column_nonvalid_rows,
+            " for problems.",
+        )
+        return False
+
+
+def check_integer_col(input):
+    column = input.map(type).eq(int)
+    validity = column.all()
+    if validity == True:
+        logger.info("The positional argument column only contains integers.")
+        return True
+    else:
+        logger.error(
+            "The positional argument column contains non-integer values. Please check your start/end column for problems."
+        )
+        return False
+
+
+def check_startend_col(input):
+    all_rows_valid = all(input.iloc[:, 1] < input.iloc[:, 2])
+    if all_rows_valid == False:
+        nonvalid_rows = input[input.iloc[:, 1] >= input.iloc[:, 2]].index.tolist()
+        logger.error(
+            "Not all start positions are smaller than their respective end positions. Please check the rows ",
+            nonvalid_rows,
+            " for problems.",
+        )
+        return False
+    else:
+        return True
+
+
+def main(argv=None):
+    """Coordinate argument parsing and program execution."""
+    args = parse_args(argv)
+    logging.basicConfig(level=args.log_level, format="[%(levelname)s] %(message)s")
+    if not args.file_in.is_file():
+        logger.error(f"The given input file {args.file_in} was not found!")
+        raise ValueError(f"The given input file {args.file_in} was not found!")
+    else:
+        bed_well_structured = check_bed_structure(args.file_in)
+        if bed_well_structured == True:
+            structured_out = pd.DataFrame(
+                {"bed_well_structured": [bed_well_structured]}
+            )
+            structured_out.to_csv("bed_stats_structure.txt", header=False, index=False)
+        else:
+            raise ValueError(
+                f"The given BED file is not well structured! Please check for floats, strings or thereof in your file!"
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/local/tmbcalculation/resources/usr/bin/calculate_TMB.py
+++ b/modules/local/tmbcalculation/resources/usr/bin/calculate_TMB.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+import numpy as np
+import pyranges as pr
+import matplotlib.pyplot as plt
+import seaborn as sns
+from pathlib import Path
+import argparse
+import logging
+import sys
+
+logger = logging.getLogger()
+
+
+def parse_args(argv=None):
+    """Define and immediately parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Calculate TMB and plot AF distribution",
+        epilog="Example: python3 calculate_TMB.py input.tsv",
+    )
+    parser.add_argument(
+        "--file_in",
+        metavar="file_in",
+        type=Path,
+        help="Input tsv file of the vembrane TSV converter module",
+    )
+    parser.add_argument(
+        "--bedfile",
+        metavar="bedfile",
+        type=Path,
+        help="Path to the provided BED-file with .bed suffix.",
+    )
+    parser.add_argument(
+        "--panelsize_threshold",
+        metavar="panelsize_threshold",
+        type=int,
+        help="Expected minimal size of the BED-file before giving an error.",
+    )
+    parser.add_argument(
+        "--min_AF",
+        metavar="min_AF",
+        type=float,
+        help="Minimal AF threshold for the filtering procedure of the TMB module",
+    )
+    parser.add_argument(
+        "--max_AF",
+        metavar="max_AF",
+        type=float,
+        help="Maximal AF threshold for the filtering procedure of the TMB module",
+    )
+    parser.add_argument(
+        "--min_cov",
+        metavar="min_cov",
+        type=int,
+        help="Minimal coverage threshold for the filtering procedure of the TMB module",
+    )
+    parser.add_argument(
+        "--popfreq_max",
+        metavar="popfreq_max",
+        type=float,
+        help="Maximal prevalence AF in the --population_db database",
+    )
+    parser.add_argument(
+        "--filter_muttype",
+        metavar="filter_muttype",
+        type=str,
+        choices=["snv", "snvs", "mnv", "mnvs"],
+        help="Set the conditions for filtering, either selecting only SNVs, SNVs and MNVs or the whole dataset including InDels",
+    )
+    parser.add_argument(
+        "--population_db",
+        metavar="population_db",
+        type=str,
+        help="String corresponding to the column name of the desired population database to filter on.",
+    )
+    parser.add_argument(
+        "--file_out",
+        metavar="FILE_OUT",
+        type=Path,
+        help="Per Sample TMB value",
+    )
+    parser.add_argument(
+        "--plot_out",
+        metavar="PLOT_OUT",
+        type=Path,
+        help="Stacked histogramm of the AFs in the sample",
+    )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        help="The desired log level (default WARNING).",
+        choices=("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
+        default="WARNING",
+    )
+    return parser.parse_args(argv)
+
+
+logger = logging.getLogger()
+
+
+def preprocess_vembraneout(file_in, filter_muttype, population_db):
+    TMB_inputfile = pd.read_csv(file_in, sep="\t")
+    TMB_inputfile["Mut_ID"] = TMB_inputfile[["CHROM", "POS", "REF", "ALT"]].apply(
+        lambda row: ":".join(row.values.astype(str)), axis=1
+    )
+    TMB_deduplicated = TMB_inputfile.drop_duplicates("Mut_ID", keep="first")
+    filtering_rates = []
+    filtering_rates.append(len(TMB_deduplicated["Mut_ID"]))
+    ### reduce dataset on relevant columns for TMB calculation
+    TMB_minimal = TMB_deduplicated.filter(
+        items=[
+            "Mut_ID",
+            "CHROM",
+            "POS",
+            "REF",
+            "ALT",
+            "FILTER",
+            "allele_fraction",
+            "read_depth",
+            "CSQ_VARIANT_CLASS",
+            "CSQ_Consequence",
+            population_db,
+        ],
+        axis=1,
+    )
+    if filter_muttype in ["snv", "snvs"]:
+        TMB_filtered = filter_onlySNV(TMB_minimal)
+    elif filter_muttype in ["mnv", "mnvs"]:
+        TMB_filtered = filter_retainMNV(TMB_minimal)
+    else:
+        TMB_filtered = TMB_minimal
+    filtering_rates.append(len(TMB_filtered["Mut_ID"]))
+    ### Generate position specific identifier for deduplication / counting
+    return (TMB_filtered, filtering_rates)
+
+
+def filter_onlySNV(TMB_inputfile):
+    TMB_onlySNV = TMB_inputfile[
+        (TMB_inputfile["REF"].isin(["A", "G", "T", "C"]))
+        & (TMB_inputfile["ALT"].isin(["A", "G", "T", "C"]))
+    ].reset_index(drop=True)
+    if TMB_onlySNV["CSQ_VARIANT_CLASS"].eq("SNV").all():
+        return TMB_onlySNV
+    else:
+        TMB_onlySNV = TMB_onlySNV[(TMB_onlySNV["CSQ_VARIANT_CLASS"] == "SNV")]
+        return TMB_onlySNV
+
+
+def filter_retainMNV(TMB_inputfile):
+    TMB_SNVs = TMB_inputfile[
+        (TMB_inputfile["REF"].isin(["A", "G", "T", "C"]))
+        & (TMB_inputfile["ALT"].isin(["A", "G", "T", "C"]))
+    ].reset_index(drop=True)
+    TMB_MNVs = TMB_inputfile[
+        (TMB_inputfile["CSQ_VARIANT_CLASS"] == "substitution")
+    ].reset_index(
+        drop=True
+    )  ### contains DBS, SNVs close to repeats and non-normalized SNVs close to InDels
+    TMB_return = pd.concat([TMB_SNVs, TMB_MNVs])
+    return TMB_return
+
+
+def check_bed_size(bedfile, breaking_thresh):
+    panel_data = pd.read_csv(bedfile, sep="\t", header=None)
+    panel_data = panel_data.iloc[:, 0:3]
+    panel_data.columns = ["Chromosome", "Start", "End"]
+    panel_range = pr.PyRanges(panel_data)
+    panel_size = panel_range.length
+    if panel_size >= breaking_thresh:
+        if panel_size >= 1000000:
+            logger.info(
+                "The provided BED file covers "
+                + str(panel_size)
+                + " basepairs. It covers more than 1 Mbp. TMB calculation can be performed"
+            )
+            return True, panel_size
+        else:
+            logger.warning(
+                "The provided BED file covers "
+                + str(panel_size)
+                + " basepairs. It covers less than 1 Mbp, but is above the breaking threshold. TMB calculation can be performed, but could be biased."
+            )
+            return True, panel_size
+    elif panel_size < breaking_thresh:
+        logger.warning(
+            "The provided BED file covers "
+            + str(panel_size)
+            + " basepairs, but does not surpass the threshold for TMB calculation. Reconsider the threshold or provide an actualized BED-file."
+        )
+        return False, panel_size
+    else:
+        logger.warning(
+            "An unexpected error occured while parsing the BED-file size. TMB calculation will not be performed."
+        )
+        return False, False
+
+
+def coverage_filter(input, threshold):
+    TMB_covfilt = input[(input["read_depth"] >= threshold)].reset_index(drop=True)
+    filtering_rates = len(TMB_covfilt["Mut_ID"])
+    return (TMB_covfilt, filtering_rates)
+
+
+def allelefrequency_filter(input, lower_threshold, higher_threshold):
+    TMB_AFboundariesfilt = input[
+        (input["allele_fraction"] >= lower_threshold)
+        & (input["allele_fraction"] <= higher_threshold)
+    ].reset_index(drop=True)
+    filtering_rates = len(TMB_AFboundariesfilt["Mut_ID"])
+    return (TMB_AFboundariesfilt, filtering_rates)
+
+
+def popfrequency_filter(input, database, threshold):
+    TMB_popfreqfilt = input[input[database] <= threshold].reset_index(drop=True)
+    filtering_rates = len(TMB_popfreqfilt["Mut_ID"])
+    return (TMB_popfreqfilt, filtering_rates)
+
+
+def calculate_TMB(input, panel_size):
+    TMB = round((len(input.index) / panel_size) * 1000000, 2)
+    return TMB
+
+
+def plot_TMB(input, name_convention, lower_af, higher_af):
+    ### Preprocess for plotting
+    counts_consequence = input.groupby(
+        input.columns.tolist(), as_index=False, dropna=False
+    ).size()
+    index_filter = (
+        counts_consequence.groupby("Mut_ID")["size"]
+        .transform("max")
+        .ne(counts_consequence["size"])
+    )
+    most_prevalent_con = counts_consequence[~index_filter.values]
+    TMB_forplot = (
+        pd.DataFrame(
+            {
+                "Mut_ID": most_prevalent_con["Mut_ID"],
+                "CSQ_Consequence": most_prevalent_con["CSQ_Consequence"],
+            }
+        )
+        .merge(input)
+        .drop_duplicates()
+    )
+    TMB_forplot["CSQ_Consequence"] = (
+        TMB_forplot["CSQ_Consequence"].str.split("&").str[0]
+    )  ## beautification
+    TMB_forplot = TMB_forplot.drop_duplicates("Mut_ID", keep="first")
+
+    ### Draw the plot
+    fig, ax = plt.subplots(figsize=(14, 8))
+
+    p = sns.histplot(
+        data=TMB_forplot,
+        ax=ax,
+        stat="count",
+        multiple="stack",
+        binwidth=0.01,
+        x="allele_fraction",
+        kde=False,
+        palette="colorblind",
+        hue="CSQ_Consequence",
+        element="bars",
+    )
+
+    ### Control the legend
+    sns.move_legend(
+        p, loc="center right", bbox_to_anchor=(1.35, 0.5), ncol=1, fontsize=6
+    )
+
+    ### Show filtering parameters
+    plt.axvline(x=lower_af, color="grey", linestyle="dotted")
+    plt.axvline(x=higher_af, color="grey", linestyle="dotted")
+
+    # Set the title and labels
+    ax.set_title("Allele frequency (AF) distribution for TMB-filtered variants")
+    ax.set_xlabel("AF in %")
+    ax.set_ylabel("# of mutations")
+    plt.xticks(np.arange(0, 1.1, 0.1))
+    ax.yaxis.get_major_locator().set_params(integer=True)  ## force integers on y-axis
+    plt.savefig(name_convention, bbox_inches="tight")
+
+
+def main(argv=None):
+    """Coordinate argument parsing and program execution."""
+    args = parse_args(argv)
+    if not args.file_in.is_file():
+        logger.error(f"The given input file {args.file_in} was not found!")
+
+    # Need to adjust parameters of zero is passed to avoid None input
+    if args.min_cov is None:
+        args.min_cov = 0.00
+    if args.min_AF is None:
+        args.min_AF = 0.00
+    if args.panelsize_threshold is None:
+        args.panelsize_threshold = 0
+
+    TMB_df, filtering_rates_total = preprocess_vembraneout(
+        args.file_in, args.filter_muttype, args.population_db
+    )
+    eligibility, panel_size = check_bed_size(args.bedfile, args.panelsize_threshold)
+    if eligibility == True:
+        TMB_covfilt, filtering_rates_cov = coverage_filter(TMB_df, args.min_cov)
+        TMB_affilt, filtering_rates_af = allelefrequency_filter(
+            TMB_covfilt, args.min_AF, args.max_AF
+        )
+        TMB_popfilt, filtering_rates_popfreq = popfrequency_filter(
+            TMB_affilt, args.population_db, args.popfreq_max
+        )
+        TMB_value = calculate_TMB(TMB_popfilt, panel_size)
+        filtering_rates_total = filtering_rates_total + [
+            filtering_rates_cov,
+            filtering_rates_af,
+            filtering_rates_popfreq,
+        ]
+        plot_TMB(
+            TMB_covfilt, args.plot_out, args.min_AF, args.max_AF
+        )  ### Use coverage filtered data as non-filtered data compresses plot to uselessness...
+        with open(args.file_out, "w") as file:
+            file.write(
+                f"Inital amount of unique mutations: {filtering_rates_total[0]} mutations\n"
+            )
+            if args.filter_muttype in ["snv", "snvs", "mnv", "mnvs"]:
+                file.write(
+                    f"Retained mutations after filtering for mutation type {args.filter_muttype}: {filtering_rates_total[1]} mutations\n"
+                )
+            file.write(
+                f"Retained mutations after applying coverage filter for a threshold below {args.min_cov}: {filtering_rates_total[2]} mutations\n"
+            )
+            file.write(
+                f"Retained mutations after filtering for AF between {args.min_AF} and {args.max_AF}: {filtering_rates_total[3]} mutations\n"
+            )
+            file.write(
+                f"Retained mutations after filtering for the population AF from {args.population_db} below {args.popfreq_max}: {filtering_rates_total[4]} mutations\n"
+            )
+            file.write(
+                f"The final TMB based on these filtering conditions and a panel size of {panel_size}: {TMB_value} mutations/Mbp"
+            )
+    else:
+        logger.info(
+            "The calculation was not performed as the panel_size is below the allowed threshold."
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/local/vcfchecks/resources/usr/bin/check_vcf.py
+++ b/modules/local/vcfchecks/resources/usr/bin/check_vcf.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+
+import pandas as pd
+import re
+import argparse
+import gzip
+from itertools import chain
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="This script checks vcf files.")
+    parser.add_argument(
+        "--meta_id",
+        help="Meta ID representing the sample name used in warning messages.",
+        type=str,
+    )
+    parser.add_argument(
+        "--vcf_in",
+        help="VCF file path.",
+        type=str,
+    )
+    parser.add_argument(
+        "--bcftools_stats_in",
+        help="bcftools stats file.",
+        type=str,
+    )
+    parser.add_argument(
+        "--warnings_out",
+        help="name of .txt file to save warnings.",
+        type=str,
+    )
+    parser.add_argument(
+        "--check_chr_prefix",
+        help='Check if CHROM column always has "chr" prefix.',
+        action="store_true",
+    )
+    parser.add_argument(
+        "--check_MNPs",
+        help="Check if provided VCF contains multinucleotide variants.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--check_vep_annotation",
+        help="Check if provided VCF is already annotated with VEP.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--check_FILTERs",
+        help='Check if provided VCF has FILTER entries other than "PASS" or "."',
+        action="store_true",
+    )
+    parser.add_argument(
+        "--check_gVCF",
+        help="Check if provided VCF contains genomic, nonvariant positions.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--check_other_variants",
+        help="Check if provided VCF has other variants than SNVs and indels.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--check_multiallelic_sites",
+        help="Check if provided VCF file has multiallelic sites.",
+        action="store_true",
+    )
+
+    return parser.parse_args()
+
+
+def read_vcf(vcf_in):
+    vcffile = pd.read_csv(vcf_in, sep="\t", comment="#", header=None)
+    if len(vcffile.columns) < 10:
+        raise ValueError(
+            "ERROR: Your VCF file has less than 10 columns and may miss columns."
+        )
+    else:
+        vcffile.columns = [
+            "CHROM",
+            "POS",
+            "ID",
+            "REF",
+            "ALT",
+            "QUAL",
+            "FILTER",
+            "INFO",
+            "FORMAT",
+        ] + ["SAMPLE{}".format(i) for i in range(1, len(vcffile.columns) - 8)]
+    return vcffile
+
+
+def read_vcf_header(vcf_in):
+    header = []
+    if vcf_in.endswith(".gz"):
+        with gzip.open(vcf_in, "rt") as f:
+            for l in f:
+                if l.startswith("##"):
+                    header.append(l.strip("\n"))
+    else:
+        with open(vcf_in, "rt") as f:
+            for l in f:
+                if l.startswith("##"):
+                    header.append(l.strip("\n"))
+    return header
+
+
+def check_chrom_def(vcffile, meta_id, log_level):
+    """
+    Check if the chromosome column always has the "chr" prefix.
+    """
+    # extract chromosomes
+    chromosomes = vcffile["CHROM"]
+
+    if chromosomes.dtype == "int":
+        report_message = f'{log_level}: {meta_id} "CHROM" column only contains integers. Chromosome names need the "chr" prefix in the "CHROM" column.'
+    else:
+        # check for pattern
+        pattern = re.compile(r"^chr.*")
+        chrmatch = [bool(pattern.match(c)) for c in chromosomes]
+        if all(chrmatch):
+            report_message = (
+                f'CHECK: {meta_id} always contains "chr" prefix in the CHROM column.'
+            )
+        else:
+            error_indices = [idx for idx, result in enumerate(chrmatch) if not result]
+            report_message = (
+                f'{log_level}: {meta_id} contains records without "chr" prefix in the CHROM column. '
+                f"{len(error_indices)} out of {len(chromosomes)} records do not have this prefix, e.g. have chromosome defined like this entry: {chromosomes[error_indices[0]]}. "
+                'Please use the "chr" prefix consistently for all entries.'
+            )
+    return report_message
+
+
+def check_VEP(vcffile, vcfheader, meta_id, log_level):
+    """
+    Check for already present VEP annotations in the VCF file.
+    First, it checks the presence of a VEP flag in the header.
+    Then, it checks if a CSQ string is present in the INFO column.
+    """
+
+    if "VEP" in vcfheader:
+        report_message = f"{log_level}: {meta_id} contains a VEP key in VCF header. If the VCF file contains previous annotations, these will be overwritten."
+    elif [any("CSQ" in e for e in vcffile["INFO"])][0]:
+        report_message = f"{log_level}: {meta_id} contains a CSQ key in the INFO column entries. If the VCF file contains previous annotations, these will be overwritten."
+    else:
+        report_message = f"CHECK: {meta_id} is not annotated by VEP yet."
+    return report_message
+
+
+def check_FILTERs(vcffile, meta_id, log_level, passfilters={"PASS", "."}):
+    """
+    Checks if FILTER column has anything else than "." or "PASS".
+    If VCF FILTER columns has ".", i.e. no filter was applied, PyVCF convert it to "None" and "PASS" is converted to an empty list "[]".
+    Hence to check for both, we need to check for non-empty strings
+    """
+
+    # get unique FILTER col entries from all vcf records
+    def get_entries_FILTER_col(vcffile):
+        # get filtervalues and split multiple values
+        filters = vcffile["FILTER"].str.split(";")
+        # remove nested list and get unique entries
+        allfilters = set(chain.from_iterable(filters))
+        # get unique entries
+        return allfilters
+
+    # check if any other filtervalues are present.
+    def check_pass(filters):
+        otherfilters = filters.difference(passfilters)
+        if not otherfilters:
+            report_message = (
+                f'CHECK: {meta_id} contains only "." or "PASS" values in FILTER column.'
+            )
+        else:
+            # if anything else than "PASS" or "." is present, report.
+            report_message = f"{log_level}: {meta_id} contains other FILTER values than \"PASS\" or \".\": {','.join(otherfilters)}. If pass_filter = true, these will be filtered."
+        return report_message
+
+    # Check in records
+    filters = get_entries_FILTER_col(vcffile)
+    report_message = check_pass(filters)
+
+    return report_message
+
+
+def check_stats_value(
+    statsfile,
+    pattern,
+    textsnippet,
+    meta_id,
+    tabposition=4,
+    intcheck=0,
+    log_level="WARNING",
+):
+    """
+    This function generally opens the stats file, searches for a string to match and extracts a tab-delimited position.
+    This position is assumed to be integer and checked against a specific intcheck number.
+    Hence, you can extract specific values in the bcftools stats file and check them directly.
+    The textsnippet argument adds specific error messages for better readability.
+    """
+
+    def process_lines(line):
+        # strip newline
+        foundline = line.strip("\n")
+        # split tabs
+        tabs = re.split("\t", foundline)
+        # extract tabposition and return
+        return tabs[tabposition - 1]
+
+    # open file
+    with open(statsfile, "r") as file:
+        matches = []
+        for line in file:
+            # important: the line is no comment line.
+            if pattern in line and not line.startswith("#"):
+                matches.append(process_lines(line))
+    if len(matches) != 1:
+        print(f"ERROR: {pattern} matches more than one line on stats file.")
+
+    if int(matches[0]) > intcheck:
+        report_message = f"{log_level}: {meta_id} contains {matches[0]} {textsnippet}."
+    else:
+        report_message = (
+            f"CHECK: {meta_id} contains equal or less than {intcheck} {textsnippet}."
+        )
+    return report_message
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+
+    """
+    meta_id is always needed to reassign the sample name when warnings are collated in the workflow.
+    The log_level determines a string that will be handled as following:
+        "ERROR": raise ValueError, workflow will stop.
+        "WARNING": The whole warning message will be collected in warnings_out and reported in multiQC file.
+    """
+
+    # load VCF as pyVCF object. This checks VCF format as well.
+    vcffile = read_vcf(args.vcf_in)
+    vcfheader = read_vcf_header(args.vcf_in)
+
+    # Run all checks and collect feedback in report_message list
+    report_message = []
+
+    # Checks through VCF file:
+    # The input for all functions needs to be a PyVCF reader class object.
+    if args.check_chr_prefix:
+        report_message = report_message + [
+            check_chrom_def(vcffile, meta_id=args.meta_id, log_level="ERROR")
+        ]
+
+    if args.check_vep_annotation:
+        report_message = report_message + [
+            check_VEP(vcffile, vcfheader, meta_id=args.meta_id, log_level="WARNING")
+        ]
+
+    if args.check_FILTERs:
+        report_message = report_message + [
+            check_FILTERs(vcffile, meta_id=args.meta_id, log_level="WARNING")
+        ]
+
+    # Input checks based on bcftools stats output.
+    if args.check_MNPs:
+        report_message = report_message + [
+            check_stats_value(
+                args.bcftools_stats_in,
+                pattern="number of MNPs",
+                textsnippet="MNPs (multinucleotide variants)",
+                meta_id=args.meta_id,
+            )
+        ]
+
+    if args.check_gVCF:
+        report_message = report_message + [
+            check_stats_value(
+                args.bcftools_stats_in,
+                pattern="number of no-ALTs",
+                textsnippet="nonvariant genomic postions (no-ALTs)",
+                meta_id=args.meta_id,
+            )
+        ]
+
+    if args.check_other_variants:
+        report_message = report_message + [
+            check_stats_value(
+                args.bcftools_stats_in,
+                pattern="number of others",
+                textsnippet='"other" variants that are neither SNPs nor indels',
+                meta_id=args.meta_id,
+            )
+        ]
+
+    if args.check_multiallelic_sites:
+        report_message = report_message + [
+            check_stats_value(
+                args.bcftools_stats_in,
+                pattern="number of multiallelic sites",
+                textsnippet="variants with multiallelic sites. These will be splitted by `bcftools norm` into biallelic sites",
+                meta_id=args.meta_id,
+            )
+        ]
+
+    # If log_level is set to "ERROR": crash and report ALL check messages
+    if any(["ERROR" in m for m in report_message]):
+        raise ValueError("\n".join(report_message))
+
+    # If log_level is set to "WARNING". collect only those in warnings_out for including in multiQC report.
+    warnings = []
+    for m in report_message:
+        if "WARNING" in m:
+            warnings.append(m)
+
+    with open(args.warnings_out, "xt") as warning_out:
+        warning_out.write("\n".join(warnings))
+
+    # Report messages also to stdin
+    print(f"{args.meta_id} VCF check was successful:\n" + "\n".join(report_message))

--- a/modules/local/vembrane/create-vembrane-fields/resources/usr/bin/create_vembrane_fields.py
+++ b/modules/local/vembrane/create-vembrane-fields/resources/usr/bin/create_vembrane_fields.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+
+import re
+import argparse
+from typing import List, Union
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description='The general purpose of this script is to easily convert annotation fields into vembrane input parameters. \
+        The input are field names from the INFO/FORMAT column or CSQ annotation string in the VCF file. \
+        The output has the format: column_name["input_field"] FOR INFO and CSQ column and FORMAT["format_field"][sampleindex] for FORMAT column fields. \
+        You can also directly perform calculation operations which will be transcribed to vembrane-compatible fields. \
+        , e.g. , AD[1]/DP in --format_fields will be converted to FORMAT["AD"][sampleindex][0]/FORMAT["DP"][sampleindex]. \
+        Vembrane interprets this operation and divides the AD value by the DP value.'
+    )
+    parser.add_argument(
+        "--csq_fields",
+        help="space-separated CSQ fields. The fields only allow letters, numbers, underscores, square brackets and mathematical operands.",
+        type=str,
+        nargs="+",
+    )
+    parser.add_argument(
+        "--format_fields",
+        help="space-separated FORMAT fields. The fields only allow letters, numbers, underscores, square brackets and mathematical operands.",
+        type=str,
+        nargs="+",
+    )
+    parser.add_argument(
+        "--info_fields",
+        help="space-separated INFO fields. The fields only allow letters, numbers, underscores, square brackets and mathematical operands.",
+        type=str,
+        nargs="+",
+    )
+    parser.add_argument(
+        "--other_fields",
+        help="comma-separated fields. This field will NOT be formatted and just added to vembrane and header line. The fields only allow letters, numbers, underscores, square brackets and mathematical operands.",
+        type=str,
+        nargs="+",
+    )
+    parser.add_argument(
+        "--allele_fraction",
+        help="Specify here how to calculate allele_fraction. Only allows values: FORMAT_AF, FORMAT_AD, mutect2, freebayes.",
+        choices=["FORMAT_AF", "FORMAT_AD", "mutect2", "freebayes"],
+        type=str,
+    )
+    parser.add_argument(
+        "--read_depth",
+        help='Specify here from which FORMAT field to extract read depth. The column will always be named "read_depth" for downstream compatibility.',
+        type=str,
+    )
+    parser.add_argument(
+        "--file_out",
+        help="output file for temporary storing vembrane and header strings.",
+        type=str,
+    )
+
+    return parser.parse_args()
+
+
+def input_check(input_strings):
+    for input_string in input_strings:
+        if re.fullmatch(r"^[A-Za-z0-9+\-*/\[\]_]+$", input_string) is None:
+            raise ValueError(
+                f'Error: The input_field "{input_string}" should only contain letters, numbers, square brackets, mathematical operands or underscores.'
+            )
+
+
+def formatting_field(
+    input_field: str,
+    column_name: str,
+    all_samples: bool,
+) -> str:
+    """
+    This function formats a single field according to vembrane input. It generates an vembrane input string and header string.
+    The fields are split by mathematical operands, which are then processed by formatting_mathfield().
+    """
+
+    def formatting_mathfield(mathsplit_field: str, input_field: str) -> str:
+        # only use letters and underscores (no brackets and numbers)
+        only_field = re.sub(r"[^A-Za-z_]", "", mathsplit_field)
+
+        # Formatting fields for header lines: only column_name underscore field
+        header_field = f"{column_name}_{only_field}"
+        # formatting fields for vembrane input
+        only_field_formatted = f'{column_name}["{only_field}"]'
+
+        # add sample index fields
+        if all_samples:
+            header_field += "[{sample}]"
+            only_field_formatted += "[s]"
+
+        # replace from original field; this preserves brackets and numbers from the input.
+        header_field = re.sub(only_field, header_field, input_field)
+        input_field_formatted = re.sub(only_field, only_field_formatted, input_field)
+
+        # if all_samples is true, iterate through each sample in vembrane
+        if all_samples:
+            header_field = 'for_each_sample(lambda sample: f"' + header_field + '")'
+            input_field_formatted = (
+                "for_each_sample(lambda s: " + input_field_formatted + ")"
+            )
+
+        return input_field_formatted, header_field
+
+    # first split input by mathematical operands
+    mathsplit_fields = re.split(r"[+\-*/]", input_field)
+    # define format_field that will be subsequently manipulated
+    for mathsplit_field in mathsplit_fields:
+        # allow number-only fields and do not format them
+        if re.match(r"[0-9]", mathsplit_field) is not None:
+            pass
+        else:
+            input_field, header_field = formatting_mathfield(
+                mathsplit_field, input_field
+            )
+
+    return input_field, header_field
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    vembrane_strings = []
+    header_strings = []
+
+    if args.other_fields:
+        # Formatting fields coming from external arguments.
+        for other_field in args.other_fields:
+            vembrane_strings.append(other_field)
+            header_strings.append(other_field)
+
+    # add allele fraction in here
+    if args.allele_fraction:
+        if args.allele_fraction in ["mutect2", "FORMAT_AF"]:
+            vembrane_strings.append(
+                'for_each_sample(lambda s: FORMAT["AF"][s] if FORMAT["AF"][s] else None)'
+            )
+            header_strings.append(
+                'for_each_sample(lambda sample: f"allele_fraction{sample}")'
+            )
+        elif args.allele_fraction in ["freebayes", "FORMAT_AD"]:
+            vembrane_strings.append(
+                'for_each_sample(lambda s: FORMAT["AD"][s][1]/FORMAT["DP"][s] if FORMAT["AD"][s][1] and FORMAT["DP"][s] else None)'
+            )
+            header_strings.append(
+                'for_each_sample(lambda sample: f"allele_fraction{sample}")'
+            )
+        else:
+            raise ValueError("ERROR: Did not specify correct allele_fraction.")
+
+    # add read depth
+    if args.read_depth:
+        vembrane_strings.append(
+            'for_each_sample(lambda s: FORMAT["' + str(args.read_depth) + '"][s])'
+        )
+        header_strings.append('for_each_sample(lambda sample: f"read_depth{sample}]")')
+
+    if args.format_fields:
+        # Formatting the FORMAT fields.
+        input_check(args.format_fields)
+        for format_field in args.format_fields:
+            format_field, format_header_field = formatting_field(
+                input_field=format_field,
+                column_name="FORMAT",
+                all_samples=True,
+            )
+            vembrane_strings.append(format_field)
+            header_strings.append(format_header_field)
+
+    if args.info_fields:
+        # Formatting the INFO fields.
+        input_check(args.info_fields)
+        for info_field in args.info_fields:
+            info_field, info_header_field = formatting_field(
+                input_field=info_field,
+                column_name="INFO",
+                all_samples=False,
+            )
+            vembrane_strings.append(info_field)
+            header_strings.append(info_header_field)
+
+    if args.csq_fields:
+        # Formatting the CSQ fields.
+        input_check(args.csq_fields)
+        for csq_field in args.csq_fields:
+            csq_field, csq_header_field = formatting_field(
+                input_field=csq_field,
+                column_name="CSQ",
+                all_samples=False,
+            )
+            vembrane_strings.append(csq_field)
+            header_strings.append(csq_header_field)
+
+    vembrane_out = ",".join(vembrane_strings)
+    header_out = ",".join(header_strings)
+
+    with open(args.file_out, "wt") as f:
+        f.write(vembrane_out + "\n" + header_out)

--- a/modules/local/vembrane/create-vembrane-tags/resources/usr/bin/create_vembrane_tags.py
+++ b/modules/local/vembrane/create-vembrane-tags/resources/usr/bin/create_vembrane_tags.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import pandas as pd
+import argparse
+import re
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Reads in TSV file with filter definitions and formats into vembrane tag input. \
+        The general filter expression follow a python syntax with the guidelines at https://github.com/vembrane/vembrane#vembrane-filter"
+    )
+    parser.add_argument(
+        "--filterdefinitions",
+        help="tab-separated file with filter name in first column and filter expression in second column.",
+        type=str,
+    )
+
+    return parser.parse_args()
+
+
+def input_check(input_strings):
+    for input_string in input_strings:
+        if re.fullmatch(r"^[A-Za-z0-9_]+$", input_string) is None:
+            raise ValueError(
+                f'Error: The input_field "{input_string}" should only contain letters, numbers and underscores.'
+            )
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+
+    # import predefined filters from TSV
+    filterdef_df = pd.read_csv(
+        args.filterdefinitions,
+        sep="\t",
+    )
+
+    # check TSV file structure
+    if not ["name", "filter"] == list(filterdef_df.columns):
+        raise ValueError(
+            f'Error: The specified filter TSV file does not have two columns named "name" and "filter": "{args.filterdefinitions}".'
+        )
+    # only allow numbers, letters and underscore for filter names
+    input_check(filterdef_df["name"])
+
+    # format for tagging
+    filter_argument = (
+        "--tag=" + filterdef_df["name"] + "='" + filterdef_df["filter"] + "'"
+    )
+
+    # concatenate
+    filters = " ".join(filter_argument)
+
+    print(filters)

--- a/workflows/variantinterpretation.nf
+++ b/workflows/variantinterpretation.nf
@@ -36,7 +36,6 @@ include { DUMP_WARNINGS               } from '../modules/local/multiqcreport_war
     RUN MAIN WORKFLOW
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-
 workflow VARIANTINTERPRETATION {
 
     take:
@@ -55,7 +54,6 @@ workflow VARIANTINTERPRETATION {
     ch_custom_filters
 
     main:
-
     // gather versions of each process
     ch_versions = Channel.empty()
     // gather QC reports for multiQC
@@ -71,6 +69,7 @@ workflow VARIANTINTERPRETATION {
     if (!params.tsv && params.calculate_tmb) error("ERROR: Need to create TSV file for calculating TMB.")
     if (!params.bedfile && params.calculate_tmb) error("ERROR: Need to specify bedfile for calculating TMB.")
     if (!params.read_depth && params.calculate_tmb) error("ERROR: Need to specify the read_depth FORMAT field for calculating TMB.")
+
 
     //
     // Index vcf and reference files
@@ -215,6 +214,29 @@ workflow VARIANTINTERPRETATION {
             }
         }
     }
+
+    emit:
+    ch_versions
+    ch_multiqc_files
+    ch_warnings
+
+}
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RUN MAIN WORKFLOW WITH MULTIQC
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+workflow MULTIQC_REPORT {
+
+    take:
+
+    ch_versions
+    ch_multiqc_files
+    ch_warnings
+
+    main:
 
     //
     // Collate and save software versions

--- a/workflows/variantinterpretation.nf
+++ b/workflows/variantinterpretation.nf
@@ -39,8 +39,8 @@ include { DUMP_WARNINGS               } from '../modules/local/multiqcreport_war
 workflow VARIANTINTERPRETATION {
 
     take:
-    ch_samplesheet  // channel: samplesheet read in from --input
-    ch_fasta           // channel: fasta file
+    ch_samplesheet
+    ch_fasta
     ch_vep_cache
     ch_vep_cache_version
     ch_vep_genome


### PR DESCRIPTION
<!--
# cio-abcd/variantinterpretation pull request

Many thanks for contributing to cio-abcd/variantinterpretation!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/cio-abcd/variantinterpretation/tree/master/.github/CONTRIBUTING.md)
-->

These changes improve the usability of the pipeline as a sub-pipeline by:
1. factoring out VARIANTINTERPRETATION_CORE from VARIANTINTERPRETATION
2. moving the pipelines scripts to their modules resources/usr/bin

This is because the multiqc configuration causes issues with a calling pipeline, e.g. wrong path to assets/.
Also, a calling pipeline might want to run multiqc in their own fashion.

The scripts under bin are visible to the whole pipeline, but not usable when the pipeline is called as a sub-pipeline/module.
The moduleBinaries under their modules resources/usr/bin are better/narrower scoped and usable to the calling pipeline.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/cio-abcd/variantinterpretation/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
