### PR TITLE
fix naming bug for BCFTOOLS_ADDROI introduced by #PR51

### DIFF
--- a/conf/modules/bedfile.config
+++ b/conf/modules/bedfile.config
@@ -33,6 +33,9 @@ process {
         publishDir = [
             enabled: false
         ]
+        ext.prefix = {
+            "${meta.id}_roi_added"
+        }
         ext.args = { [
             '--output-type z',
             '--columns CHROM,FROM,TO,ROI'


### PR DESCRIPTION

This adaption to the bedfile config fixes a bug occurring during the `bcftools annotate` step of the `tag_roi`-subworkflow when the sample ID and the provided VCF file in the samplesheet have the exact same name. By adding a temporary filename extension in the config file, this error should be fixed.